### PR TITLE
Improve source set support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ neoForge {
 
             // You can change the name used for this run in your IDE
             ideName = "Run Game Tests"
+        
+            // Changes the source set whose runtime classpath is used for this run. This defaults to "main"
+            // Eclipse does not support having multiple runtime classpaths per project (except for unit tests).
+            sourceSet = sourceSets.main
         }
     }
 }
@@ -164,6 +168,34 @@ neoForge {
             systemProperty 'forge.logging.console.level', 'debug'
         }
     }
+}
+```
+
+### Isolated Source Sets
+
+If you work with source sets that do not extend from `main`, and would like the modding dependencies to be available
+in those source sets, you can use the following api:
+
+```
+sourceSets {
+  anotherSourceSet // example
+}
+
+neoForge {
+  // ...
+  addModdingDependenciesTo(sourceSets.anotherSourceSet)
+  
+  mods {
+    mymod {
+      sourceSet sourceSets.main
+      // Do not forget to add additional soruce-sets here!
+      sourceSet sourceSets.anotherSourceSet
+    }
+  }
+}
+
+dependencies {
+  implementation sourceSets.anotherSourceSet.output
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ sourceSets {
 
 neoForge {
   // ...
-  addModdingDependenciesTo(sourceSets.anotherSourceSet)
+  addModdingDependenciesTo sourceSets.anotherSourceSet
   
   mods {
     mymod {

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ neoForge {
   mods {
     mymod {
       sourceSet sourceSets.main
-      // Do not forget to add additional soruce-sets here!
+      // Do not forget to add additional source-sets here!
       sourceSet sourceSets.anotherSourceSet
     }
   }

--- a/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
@@ -1,5 +1,6 @@
 package net.neoforged.moddevgradle.dsl;
 
+import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
 import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import org.gradle.api.Named;
 import org.gradle.api.Project;
@@ -11,6 +12,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.SourceSet;
 import org.slf4j.event.Level;
 
 import javax.inject.Inject;
@@ -49,6 +51,8 @@ public abstract class RunModel implements Named, Dependencies {
             ideName = project.getName() + " - " + ideName;
         }
         getIdeName().convention(ideName);
+
+        getSourceSet().convention(ExtensionUtils.getSourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME));
     }
 
     @Override
@@ -112,6 +116,14 @@ public abstract class RunModel implements Named, Dependencies {
     public abstract DependencyCollector getAdditionalRuntimeClasspath();
 
     public abstract Property<Level> getLogLevel();
+
+    /**
+     * Sets the source set to be used as the main classpath of this run.
+     * Defaults to the {@code main} source set.
+     * Eclipse does not support having multiple different classpaths per project beyond a separate unit-testing
+     * classpath.
+     */
+    public abstract Property<SourceSet> getSourceSet();
 
     @Override
     public String toString() {

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -5,6 +5,7 @@ import net.neoforged.moddevgradle.dsl.ModModel;
 import net.neoforged.moddevgradle.dsl.NeoForgeExtension;
 import net.neoforged.moddevgradle.dsl.RunModel;
 import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
+import net.neoforged.moddevgradle.internal.utils.IdeDetection;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -246,14 +247,12 @@ final class RunUtils {
 
     /**
      * Returns the configured output directory, only if "Build and run using" is set to "IDEA".
-     * In other cases, returns {@null}.
+     * In other cases, returns {@code null}.
      */
     @Nullable
     static File getIntellijOutputDirectory(Project project) {
-        // TODO: this doesn't work in our little testproject because the .idea folder is one level above the root...
-        var projectDir = project.getRootDir();
-        var ideaDir = new File(projectDir, ".idea");
-        if (!ideaDir.exists()) {
+        var ideaDir = IdeDetection.getIntellijProjectDir(project);
+        if (ideaDir == null) {
             return null;
         }
 
@@ -272,7 +271,7 @@ final class RunUtils {
             outputDirUrl = "file://$PROJECT_DIR$/out";
         }
 
-        outputDirUrl = outputDirUrl.replace("$PROJECT_DIR$", projectDir.getAbsolutePath());
+        outputDirUrl = outputDirUrl.replace("$PROJECT_DIR$", ideaDir.getParentFile().getAbsolutePath());
         outputDirUrl = outputDirUrl.replaceAll("^file:", "");
 
         // The output dir can start with something like "//C:\"; File can handle it.

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -271,7 +271,7 @@ final class RunUtils {
             outputDirUrl = "file://$PROJECT_DIR$/out";
         }
 
-        outputDirUrl = outputDirUrl.replace("$PROJECT_DIR$", ideaDir.getParentFile().getAbsolutePath());
+        outputDirUrl = outputDirUrl.replace("$PROJECT_DIR$", project.getProjectDir().getAbsolutePath());
         outputDirUrl = outputDirUrl.replaceAll("^file:", "");
 
         // The output dir can start with something like "//C:\"; File can handle it.

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/ExtensionUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/ExtensionUtils.java
@@ -1,7 +1,9 @@
 package net.neoforged.moddevgradle.internal.utils;
 
+import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,5 +42,9 @@ public final class ExtensionUtils {
             throw new IllegalStateException("Extension " + name + " on " + container + " is not of type " + expectedType.getName() + " but of " + extension.getClass());
         }
         return expectedType.cast(extension);
+    }
+
+    public static SourceSetContainer getSourceSets(Project project) {
+        return getExtension(project, "sourceSets", SourceSetContainer.class);
     }
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
@@ -1,5 +1,11 @@
 package net.neoforged.moddevgradle.internal.utils;
 
+import org.gradle.api.Project;
+import org.gradle.api.initialization.IncludedBuild;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+
 /**
  * Utilities for trying to detect in which IDE Gradle is running.
  */
@@ -27,4 +33,47 @@ public final class IdeDetection {
     public static boolean isEclipse() {
         return System.getProperty("eclipse.application") != null;
     }
+
+    /**
+     * Try to find the IntelliJ project directory that belongs to this Gradle project.
+     * There are scenarios where this is impossible, since IntelliJ allows adding
+     * Gradle builds to IntelliJ projects in a completely different directory.
+     */
+    @Nullable
+    public static File getIntellijProjectDir(Project project) {
+        // Always try the root directory first, since it has the highest chance
+        var intellijProjectDir = getIntellijProjectDir(project.getRootDir());
+        if (intellijProjectDir != null) {
+            return intellijProjectDir;
+        }
+
+        // Try every included build
+        for (var includedBuild : project.getGradle().getIncludedBuilds()) {
+            if (!includedBuild.getProjectDir().equals(project.getRootDir())) {
+                intellijProjectDir = getIntellijProjectDir(includedBuild.getProjectDir());
+                if (intellijProjectDir != null) {
+                    return intellijProjectDir;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static File getIntellijProjectDir(File gradleProjectDir) {
+        // Search the .idea folder belonging to this Gradle project
+        // In includeBuild scenarios, it might be above the project. It's also possible
+        // that it is completely separate.
+        var ideaDir = new File(gradleProjectDir, ".idea");
+        while (!ideaDir.exists()) {
+            gradleProjectDir = gradleProjectDir.getParentFile();
+            if (gradleProjectDir == null) {
+                return null;
+            }
+            ideaDir = new File(gradleProjectDir, ".idea");
+        }
+
+        return ideaDir;
+    }
+
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
@@ -55,19 +55,8 @@ public final class IdeDetection {
     }
 
     private static File getIntellijProjectDir(File gradleProjectDir) {
-        // Search the .idea folder belonging to this Gradle project
-        // In includeBuild scenarios, it might be above the project. It's also possible
-        // that it is completely separate.
         var ideaDir = new File(gradleProjectDir, ".idea");
-        while (!ideaDir.exists()) {
-            gradleProjectDir = gradleProjectDir.getParentFile();
-            if (gradleProjectDir == null) {
-                return null;
-            }
-            ideaDir = new File(gradleProjectDir, ".idea");
-        }
-
-        return ideaDir;
+        return ideaDir.exists() ? ideaDir : null;
     }
 
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
@@ -1,7 +1,6 @@
 package net.neoforged.moddevgradle.internal.utils;
 
 import org.gradle.api.Project;
-import org.gradle.api.initialization.IncludedBuild;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -41,13 +40,7 @@ public final class IdeDetection {
      */
     @Nullable
     public static File getIntellijProjectDir(Project project) {
-        // Always try the root directory first, since it has the highest chance
-        var intellijProjectDir = getIntellijProjectDir(project.getRootDir());
-        if (intellijProjectDir != null) {
-            return intellijProjectDir;
-        }
-
-        // Navigate to the root of the composite build tree
+        // Always try the root of a composite build first, since it has the highest chance
         var root = project.getGradle().getParent();
         if (root != null) {
             while (root.getParent() != null) {
@@ -57,7 +50,8 @@ public final class IdeDetection {
             return getIntellijProjectDir(root.getRootProject().getProjectDir());
         }
 
-        return null;
+        // As a fallback or in case of not using composite builds, try the root project folder
+        return getIntellijProjectDir(project.getRootDir());
     }
 
     private static File getIntellijProjectDir(File gradleProjectDir) {

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/IdeDetection.java
@@ -47,14 +47,14 @@ public final class IdeDetection {
             return intellijProjectDir;
         }
 
-        // Try every included build
-        for (var includedBuild : project.getGradle().getIncludedBuilds()) {
-            if (!includedBuild.getProjectDir().equals(project.getRootDir())) {
-                intellijProjectDir = getIntellijProjectDir(includedBuild.getProjectDir());
-                if (intellijProjectDir != null) {
-                    return intellijProjectDir;
-                }
+        // Navigate to the root of the composite build tree
+        var root = project.getGradle().getParent();
+        if (root != null) {
+            while (root.getParent() != null) {
+                root = root.getParent();
             }
+
+            return getIntellijProjectDir(root.getRootProject().getProjectDir());
         }
 
         return null;

--- a/testproject/build.gradle
+++ b/testproject/build.gradle
@@ -7,12 +7,17 @@ repositories {
     mavenLocal()
 }
 
+sourceSets {
+    api
+}
+
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "net.neoforged:testframework:${project.neoforge_version}"
 
     implementation project(":subproject")
+    implementation sourceSets.api.output
 }
 
 test {
@@ -21,6 +26,7 @@ test {
 
 neoForge {
     version = project.neoforge_version
+    addModdingDependenciesTo(sourceSets.api)
 
     runs {
         configureEach {
@@ -35,11 +41,16 @@ neoForge {
         server {
             server()
         }
+        apitest {
+            client()
+            sourceSet = sourceSets.api
+        }
     }
 
     mods {
         testproject {
             sourceSet sourceSets.main
+            sourceSet sourceSets.api
             dependency project(":subproject")
         }
     }

--- a/testproject/src/api/java/apitest/ApiTest.java
+++ b/testproject/src/api/java/apitest/ApiTest.java
@@ -1,0 +1,10 @@
+package apitest;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+public class ApiTest {
+    public ApiTest() {
+        new ItemStack(Items.AIR);
+    }
+}

--- a/testproject/src/main/java/testproject/TestProject.java
+++ b/testproject/src/main/java/testproject/TestProject.java
@@ -1,5 +1,6 @@
 package testproject;
 
+import apitest.ApiTest;
 import net.minecraft.DetectedVersion;
 import net.neoforged.fml.common.Mod;
 import subproject.SubProject;
@@ -9,5 +10,7 @@ public class TestProject {
     public TestProject() {
         System.out.println(DetectedVersion.tryDetectVersion().getName());
         System.out.println(SubProject.class.getName());
+
+        new ApiTest(); // access something from the api source set
     }
 }

--- a/testproject/src/main/resources/META-INF/neoforge.mods.toml
+++ b/testproject/src/main/resources/META-INF/neoforge.mods.toml
@@ -7,7 +7,7 @@
 modLoader="javafml" #mandatory
 
 # A version range to match for said mod loader - for regular FML @Mod it will be the the FML version. This is currently 47.
-loaderVersion="[3,)" #mandatory
+loaderVersion="[4,)" #mandatory
 
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
@@ -76,7 +76,7 @@ type="required" #mandatory
 # Optional field describing why the dependency is required or why it is incompatible
 # reason="..."
 # The version range of the dependency
-versionRange="[20.6,)" #mandatory
+versionRange="[21.0.0-beta,)" #mandatory
 # An ordering relationship for the dependency.
 # BEFORE - This mod is loaded BEFORE the dependency
 # AFTER - This mod is loaded AFTER the dependency
@@ -89,7 +89,7 @@ side="BOTH"
 modId="minecraft"
 type="required"
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange="[1.20.6]"
+versionRange="[1.21]"
 ordering="NONE"
 side="BOTH"
 


### PR DESCRIPTION
Allow the modding depedencies to be added to source sets that do not extend from the main source set. Also allow setting of the primary source set for runs, which also translates into that source set being set as the IntelliJ classpath module for that run.

### Isolated Source Sets

If you work with source sets that do not extend from `main`, and would like the modding dependencies to be available
in those source sets, you can use the following api:

```
sourceSets {
  anotherSourceSet // example
}
neoForge {
  // ...
  addModdingDependenciesTo(sourceSets.anotherSourceSet)
  
  mods {
    mymod {
      sourceSet sourceSets.main
      // Do not forget to add additional soruce-sets here!
      sourceSet sourceSets.anotherSourceSet
    }
  }
}
dependencies {
  implementation sourceSets.anotherSourceSet.output
}
```