### PR TITLE
Jar-in-Jar: Prefix Jar files embedded from subprojects to avoid JPMS module-name conflicts

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/jarjar/ResolvedJarJarArtifact.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/jarjar/ResolvedJarJarArtifact.java
@@ -19,13 +19,15 @@ import java.util.jar.Manifest;
 public class ResolvedJarJarArtifact {
 
     private final File file;
+    private final String embeddedFilename;
     private final String version;
     private final String versionRange;
     private final String group;
     private final String artifact;
 
-    public ResolvedJarJarArtifact(File file, String version, String versionRange, String group, String artifact) {
+    public ResolvedJarJarArtifact(File file, String embeddedFilename, String version, String versionRange, String group, String artifact) {
         this.file = file;
+        this.embeddedFilename = embeddedFilename;
         this.version = version;
         this.versionRange = versionRange;
         this.group = group;
@@ -48,13 +50,18 @@ public class ResolvedJarJarArtifact {
     }
 
     public ContainedJarMetadata createContainerMetadata() {
-        return new ContainedJarMetadata(createContainedJarIdentifier(), createContainedVersion(), "META-INF/jarjar/"+file.getName(), isObfuscated(file));
+        return new ContainedJarMetadata(createContainedJarIdentifier(), createContainedVersion(), "META-INF/jarjar/"+embeddedFilename, isObfuscated(file));
     }
 
     @InputFile
     @PathSensitive(PathSensitivity.NAME_ONLY)
     public File getFile() {
         return file;
+    }
+
+    @Input
+    public String getEmbeddedFilename() {
+        return embeddedFilename;
     }
 
     @Input

--- a/src/main/java/net/neoforged/moddevgradle/tasks/JarJar.java
+++ b/src/main/java/net/neoforged/moddevgradle/tasks/JarJar.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public abstract class JarJar extends DefaultTask {
@@ -63,6 +65,13 @@ public abstract class JarJar extends DefaultTask {
             fileSystemOperations.copy(spec -> {
                 spec.into(getOutputDirectory().dir("META-INF/jarjar"));
                 spec.from(includedJars.stream().map(ResolvedJarJarArtifact::getFile).toArray());
+                for (var includedJar : includedJars) {
+                    var originalName = includedJar.getFile().getName();
+                    var embeddedName = includedJar.getEmbeddedFilename();
+                    if (!originalName.equals(embeddedName)) {
+                        spec.rename(Pattern.quote(originalName), Matcher.quoteReplacement(embeddedName));
+                    }
+                }
                 spec.from(writeMetadata(includedJars).toFile());
             });
         }


### PR DESCRIPTION
I.e. for a subproject named `coremod` in a project with group `testmod`, the resulting jar filename would be `testproject.coremod`.
This would result in module name `testproject.coremod` when no `Automatic-Module-Name` is specified.