### PR TITLE
Fix default path detection for access transformers

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/NeoForgeExtension.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/NeoForgeExtension.java
@@ -39,7 +39,7 @@ public abstract class NeoForgeExtension {
         getAccessTransformers().convention(project.provider(() -> {
             // Only return this when it actually exists
             var mainSourceSet = ExtensionUtils.getSourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-            for (var resources : mainSourceSet.getResources()) {
+            for (var resources : mainSourceSet.getResources().getSrcDirs()) {
                 var defaultPath = new File(resources, "META-INF/accesstransformer.cfg");
                 if (project.file(defaultPath).exists()) {
                     return List.of(defaultPath.getAbsolutePath());

--- a/testproject/src/main/java/testproject/TestProject.java
+++ b/testproject/src/main/java/testproject/TestProject.java
@@ -9,6 +9,7 @@ import subproject.SubProject;
 public class TestProject {
     public TestProject() {
         System.out.println(DetectedVersion.tryDetectVersion().getName());
+        System.out.println("Top-Level: " + ((DetectedVersion) DetectedVersion.BUILT_IN).buildTime);
         System.out.println(SubProject.class.getName());
 
         new ApiTest(); // access something from the api source set


### PR DESCRIPTION
Iterating over `getResources` literally gives us all resources 😓 
Also made the root testproject actually use the access transformed class, not just the subproject (which has an explicit AT reference).