### PR TITLE
Fix wrong OS attribute on macOS

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/OperatingSystemDisambiguation.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/OperatingSystemDisambiguation.java
@@ -16,7 +16,7 @@ public abstract class OperatingSystemDisambiguation implements AttributeDisambig
         if (osName.startsWith("Linux") || osName.startsWith("LINUX")) {
             osName = "linux";
         } else if (osName.startsWith("Mac OS X")) {
-            osName = "macosx";
+            osName = "osx";
         } else if (osName.startsWith("Windows")) {
             osName = "windows";
         } else {


### PR DESCRIPTION
It should be `osx`, see https://github.com/neoforged/GradleMinecraftDependencies/blob/999449cc54c5c01fff1a66406be6e72872b75979/buildSrc/src/main/groovy/net/neoforged/minecraftdependencies/GenerateModuleMetadata.groovy#L164.