### PR TITLE
Allow + in Jar-in-Jar versions if they are not at the end

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarArtifacts.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarArtifacts.java
@@ -237,7 +237,7 @@ public abstract class JarJarArtifacts {
             throw new GradleException(errorPrefix + "no restrictions");
         } else if (data.getRecommendedVersion() != null) {
             throw new GradleException(errorPrefix + "recommended versions are unsupported");
-        } else if (range.contains("+")) {
+        } else if (range.endsWith("+")) {
             throw new GradleException(errorPrefix + "dynamic versions are unsupported");
         }
 


### PR DESCRIPTION
This fixes JiJing mods that use dual version number systems, such as `0.90.2+1.20.4`.