### PR TITLE
Remove unneeded `ModModel#sourceSet` project overload

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/ModModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/ModModel.java
@@ -47,11 +47,6 @@ public abstract class ModModel implements Named {
 
     // Do not name getSourceSets or it will conflict with project.sourceSets in scripts.
     public abstract ListProperty<SourceSet> getModSourceSets();
-
-    public void sourceSet(SourceSet sourceSet) {
-        sourceSet(sourceSet, getProject());
-    }
-
     public void dependency(CharSequence dependencyNotation) {
         getConfiguration().getDependencies().add(getProject().getDependencyFactory().create(dependencyNotation));
     }
@@ -64,11 +59,7 @@ public abstract class ModModel implements Named {
         getConfiguration().extendsFrom(configuration);
     }
 
-    public void sourceSet(SourceSet sourceSet, Project project) {
-        if (!project.getExtensions().getByType(SourceSetContainer.class).contains(sourceSet)) {
-            throw new IllegalArgumentException("Source set " + sourceSet + " does not belong to project " + project);
-        }
-
+    public void sourceSet(SourceSet sourceSet) {
         getModSourceSets().add(sourceSet);
     }
 }


### PR DESCRIPTION
It was [previously](https://github.com/neoforged/ModDevGradle/commit/8cbf83017b29a8ce3e74b4630da7087cd565f962#diff-7237cad51802b88aa176083123169dcce0b5faf4138fae6d95eb0d8cd7392027R36-R43) used to query the processResources task, however it is no longer used nor needed.