### PR TITLE
Add -XstartOnFirstThread for macOS client runs

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/OperatingSystemDisambiguation.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/OperatingSystemDisambiguation.java
@@ -1,7 +1,6 @@
 package net.neoforged.moddevgradle.internal;
 
-
-import org.gradle.api.GradleException;
+import net.neoforged.moddevgradle.internal.utils.OperatingSystem;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 
@@ -11,18 +10,10 @@ import org.gradle.api.attributes.MultipleCandidatesDetails;
 public abstract class OperatingSystemDisambiguation implements AttributeDisambiguationRule<String> {
     @Override
     public void execute(MultipleCandidatesDetails<String> details) {
-        var osName = System.getProperty("os.name");
-        // The following matches the logic in Apache Commons Lang 3 SystemUtils
-        if (osName.startsWith("Linux") || osName.startsWith("LINUX")) {
-            osName = "linux";
-        } else if (osName.startsWith("Mac OS X")) {
-            osName = "osx";
-        } else if (osName.startsWith("Windows")) {
-            osName = "windows";
-        } else {
-            throw new GradleException("Unsupported operating system: " + osName);
-        }
-
-        details.closestMatch(osName);
+        details.closestMatch(switch (OperatingSystem.current()) {
+            case LINUX -> "linux";
+            case MACOS -> "osx";
+            case WINDOWS -> "windows";
+        });
     }
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareRun.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareRun.java
@@ -41,4 +41,9 @@ abstract class PrepareRun extends PrepareRunOrTest {
     protected String resolveMainClass(UserDevRunType runConfig) {
         return getMainClass().getOrElse(runConfig.main());
     }
+
+    @Override
+    protected boolean isClientDistribution() {
+        return getRunType().get().equals("client") || getRunType().get().equals("data");
+    }
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
@@ -1,6 +1,7 @@
 package net.neoforged.moddevgradle.internal;
 
 import net.neoforged.moddevgradle.internal.utils.FileUtils;
+import net.neoforged.moddevgradle.internal.utils.OperatingSystem;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -90,6 +91,9 @@ abstract class PrepareRunOrTest extends DefaultTask {
     @Nullable
     protected abstract String resolveMainClass(UserDevRunType runConfig);
 
+    @Internal
+    protected abstract boolean isClientDistribution();
+
     private List<String> getInterpolatedJvmArgs(UserDevRunType runConfig) {
         var result = new ArrayList<String>();
         for (var jvmArg : runConfig.jvmArgs()) {
@@ -100,6 +104,10 @@ abstract class PrepareRunOrTest extends DefaultTask {
                         .collect(Collectors.joining(File.pathSeparator));
             }
             result.add(RunUtils.escapeJvmArg(arg));
+        }
+        if (isClientDistribution() && OperatingSystem.current() == OperatingSystem.MACOS) {
+            // TODO: it might be more future-proof to source this from the platform args in the MC version json
+            result.add("-XstartOnFirstThread");
         }
         return result;
     }

--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareTest.java
@@ -25,4 +25,9 @@ abstract class PrepareTest extends PrepareRunOrTest {
     protected String resolveMainClass(UserDevRunType runConfig) {
         return null; // No main class to override
     }
+
+    @Override
+    protected boolean isClientDistribution() {
+        return true;
+    }
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/OperatingSystem.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/OperatingSystem.java
@@ -1,0 +1,23 @@
+package net.neoforged.moddevgradle.internal.utils;
+
+import org.gradle.api.GradleException;
+
+public enum OperatingSystem {
+    LINUX,
+    MACOS,
+    WINDOWS;
+
+    public static OperatingSystem current() {
+        var osName = System.getProperty("os.name");
+        // The following matches the logic in Apache Commons Lang 3 SystemUtils
+        if (osName.startsWith("Linux") || osName.startsWith("LINUX")) {
+            return LINUX;
+        } else if (osName.startsWith("Mac OS X")) {
+            return MACOS;
+        } else if (osName.startsWith("Windows")) {
+            return WINDOWS;
+        } else {
+            throw new GradleException("Unsupported operating system: " + osName);
+        }
+    }
+}


### PR DESCRIPTION
Better today than "today".

Fixes #50.

Untested on macOS of course, but the argument does get added to the runs! (If I switch the OS to `WINDOWS` in the check).