### PR TITLE
Fix typo in README in neoform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Apply the plugin as usual and use a configuration block like this:
 ```groovy
 neoForge {
     // Look for versions on https://projects.neoforged.net/neoforged/neoform
-    neoFormVersion = "1.21.-20240613.152323"
+    neoFormVersion = "1.21-20240613.152323"
 
     runs {
         client {


### PR DESCRIPTION
the version is currently invalid, was a bit confusing when I tried to copy paste it the first time