### PR TITLE
Fix issues with non-ASCII characters in paths when the system property file.encoding was overriden

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -7,6 +7,7 @@ import net.neoforged.moddevgradle.dsl.RunModel;
 import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
 import net.neoforged.moddevgradle.internal.utils.FileUtils;
 import net.neoforged.moddevgradle.internal.utils.IdeDetection;
+import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import net.neoforged.moddevgradle.tasks.JarJar;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -665,7 +666,7 @@ public class ModDevPlugin implements Plugin<Project> {
                 var vmArgsFilePath = intellijVmArgsFile.get().getAsFile().toPath();
                 Files.createDirectories(vmArgsFilePath.getParent());
                 // JVM args generally expect platform encoding
-                FileUtils.writeStringSafe(vmArgsFilePath, ideSpecificVmArgs, Charset.defaultCharset());
+                FileUtils.writeStringSafe(vmArgsFilePath, ideSpecificVmArgs, StringUtils.getNativeCharset());
             } catch (IOException e) {
                 throw new GradleException("Failed to write VM args file for IntelliJ unit tests", e);
             }

--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
@@ -2,6 +2,7 @@ package net.neoforged.moddevgradle.internal;
 
 import net.neoforged.moddevgradle.internal.utils.FileUtils;
 import net.neoforged.moddevgradle.internal.utils.OperatingSystem;
+import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -24,7 +25,7 @@ import org.slf4j.event.Level;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +37,8 @@ import java.util.stream.Collectors;
  * Performs preparation for running the game or running a test.
  *
  * <p><ul>
- *     <li>Writes the JVM and program arguments for running the game to args-files.</li>
- *     <li>Creates the run folder.</li>
+ * <li>Writes the JVM and program arguments for running the game to args-files.</li>
+ * <li>Creates the run folder.</li>
  * </ul>
  */
 abstract class PrepareRunOrTest extends DefaultTask {
@@ -139,13 +140,13 @@ abstract class PrepareRunOrTest extends DefaultTask {
 
         return new UserDevConfig("", "", "", List.of(), List.of(), Map.of(
                 "client", new UserDevRunType(
-                        true, "net.minecraft.client.main.Main", clientArgs, List.of(),true, false, false, false, Map.of(), Map.of()
+                        true, "net.minecraft.client.main.Main", clientArgs, List.of(), true, false, false, false, Map.of(), Map.of()
                 ),
                 "server", new UserDevRunType(
-                true, "net.minecraft.server.Main", commonArgs, List.of(),false, true, false, false, Map.of(), Map.of()
+                        true, "net.minecraft.server.Main", commonArgs, List.of(), false, true, false, false, Map.of(), Map.of()
                 ),
                 "data", new UserDevRunType(
-                        true, "net.minecraft.data.Main", commonArgs, List.of(),false, false, true, false, Map.of(), Map.of()
+                        true, "net.minecraft.data.Main", commonArgs, List.of(), false, false, true, false, Map.of(), Map.of()
                 )
         ));
     }
@@ -188,7 +189,7 @@ abstract class PrepareRunOrTest extends DefaultTask {
                 getVmArgsFile().get().getAsFile().toPath(),
                 lines,
                 // JVM expects default character set
-                Charset.defaultCharset()
+                StringUtils.getNativeCharset()
         );
     }
 
@@ -241,8 +242,8 @@ abstract class PrepareRunOrTest extends DefaultTask {
         FileUtils.writeLinesSafe(
                 getProgramArgsFile().get().getAsFile().toPath(),
                 lines,
-                // DevLaunch reads the file using standard platform encoding
-                Charset.defaultCharset()
+                // FML Junit and DevLaunch (starting in 1.0.1) read this file using UTF-8
+                StandardCharsets.UTF_8
         );
     }
 

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -49,7 +49,7 @@ final class RunUtils {
     private RunUtils() {
     }
 
-    public static String DEV_LAUNCH_GAV = "net.neoforged:DevLaunch:1.0.0";
+    public static String DEV_LAUNCH_GAV = "net.neoforged:DevLaunch:1.0.1";
     public static String DEV_LAUNCH_MAIN_CLASS = "net.neoforged.devlaunch.Main";
 
     public static String escapeJvmArg(String arg) {

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/StringUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/StringUtils.java
@@ -2,14 +2,37 @@ package net.neoforged.moddevgradle.internal.utils;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
 @ApiStatus.Internal
 public final class StringUtils {
-    private StringUtils() {}
+    private StringUtils() {
+    }
 
     private static final Pattern NOT_LETTERS = Pattern.compile("\\P{L}");
+
+    /**
+     * Get the platform native charset. To see how this differs from the default charset,
+     * see https://openjdk.org/jeps/400. This property cannot be overriden via system
+     * property.
+     */
+    public static Charset getNativeCharset() {
+        return NativeEncodingHolder.charset;
+    }
+
+    private static class NativeEncodingHolder {
+        static final Charset charset;
+
+        static {
+            var nativeEncoding = System.getProperty("native.encoding");
+            if (nativeEncoding == null) {
+                throw new IllegalStateException("The native.encoding system property is not available, but should be since Java 17!");
+            }
+            charset = Charset.forName(nativeEncoding);
+        }
+    }
 
     /**
      * Converts an arbitrary input string to a sanitized camel case string.


### PR DESCRIPTION
Charset.defaultCharset() sadly cannot be used to write files that are always read using the Platforms native encoding, since a user can override it. Use the new `native.encoding` property instead, which cannot be overridden and contains the actual system encoding used for program arguments, etc.

Also update DevLaunch to always use UTF-8 to make it 1) reliable and 2) bring it in line with FML JUnit which parses the same argument file using UTF-8 already.