### PR TITLE
Validate run names instead of modifying invalid ones

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/InternalModelHelper.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/InternalModelHelper.java
@@ -18,6 +18,6 @@ public class InternalModelHelper {
     }
 
     public static String nameOfRun(RunModel run, @Nullable String prefix, @Nullable String suffix) {
-        return StringUtils.uncapitalize((prefix == null ? "" : prefix) + run.baseName + (suffix == null ? "" : StringUtils.capitalize(suffix)));
+        return StringUtils.uncapitalize((prefix == null ? "" : prefix) + run.getName() + (suffix == null ? "" : StringUtils.capitalize(suffix)));
     }
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/StringUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/StringUtils.java
@@ -4,14 +4,11 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.nio.charset.Charset;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 @ApiStatus.Internal
 public final class StringUtils {
     private StringUtils() {
     }
-
-    private static final Pattern NOT_LETTERS = Pattern.compile("\\P{L}");
 
     /**
      * Get the platform native charset. To see how this differs from the default charset,
@@ -32,20 +29,6 @@ public final class StringUtils {
             }
             charset = Charset.forName(nativeEncoding);
         }
-    }
-
-    /**
-     * Converts an arbitrary input string to a sanitized camel case string.
-     */
-    public static String toCamelCase(String input, boolean lower) {
-        var parts = NOT_LETTERS.split(input);
-        if (parts.length > 0 && lower) {
-            parts[0] = uncapitalize(parts[0]);
-        }
-        for (int i = lower ? 1 : 0; i < parts.length; ++i) {
-            parts[i] = capitalize(parts[i]);
-        }
-        return String.join("", parts);
     }
 
     public static String capitalize(String input) {

--- a/src/test/java/net/neoforged/moddevgradle/functional/ValidationTests.java
+++ b/src/test/java/net/neoforged/moddevgradle/functional/ValidationTests.java
@@ -1,0 +1,52 @@
+package net.neoforged.moddevgradle.functional;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidationTests {
+    @TempDir
+    File testProjectDir;
+    private File settingsFile;
+    private File buildFile;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        settingsFile = new File(testProjectDir, "settings.gradle");
+        Files.writeString(settingsFile.toPath(), "rootProject.name = 'test-project'");
+
+        buildFile = new File(testProjectDir, "build.gradle");
+    }
+
+    @Test
+    void testRunNameValidation() throws IOException {
+        Files.writeString(buildFile.toPath(), """
+                plugins {
+                    id "net.neoforged.moddev"
+                }
+                
+                neoForge {
+                    runs {
+                        validName1 {}
+                        create("invalid name") {}
+                    }
+                }
+                """);
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments("tasks")
+                .buildAndFail();
+
+        assertThat(result.getOutput()).contains("Run name 'invalid name' is invalid!");
+    }
+}

--- a/testproject/build.gradle
+++ b/testproject/build.gradle
@@ -36,6 +36,10 @@ neoForge {
         client {
             client()
         }
+        client2 {
+            client()
+            programArguments.addAll('--username', 'Dev2')
+        }
         data {
             data()
         }


### PR DESCRIPTION
A valid run name must start with a letter and can only contain letters, digits, underscores and hyphens.