### PR TITLE
Add an `additionalResults` property to the NFRT dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,9 @@ neoForge {
         // Print more information when NFRT cannot use a cached result
         // Gradle Property: neoForge.neoFormRuntime.analyzeCacheMisses
         analyzeCacheMisses = true
+        
+        // Allows pulling additional NFRT results
+        // additionalResults.put('vanillaDeobfuscated', project.file('vanilla.jar'))
     }
 }
 ```

--- a/src/main/java/net/neoforged/moddevgradle/dsl/NeoFormRuntime.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/NeoFormRuntime.java
@@ -2,9 +2,11 @@ package net.neoforged.moddevgradle.dsl;
 
 import net.neoforged.moddevgradle.internal.utils.PropertyUtils;
 import org.gradle.api.Project;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
 import javax.inject.Inject;
+import java.io.File;
 
 /**
  * Configures aspects of the NeoForm Runtime (NFRT), which is used by this plugin to produce
@@ -65,4 +67,11 @@ public abstract class NeoFormRuntime {
      * <b>Gradle property:</b> {@code neoForge.neoFormRuntime.analyzeCacheMisses}.
      */
     public abstract Property<Boolean> getAnalyzeCacheMisses();
+
+    /**
+     * Used to request additional results from NFRT.
+     * <p>
+     * Maps a result name to the file it should be written to.
+     */
+    public abstract MapProperty<String, File> getAdditionalResults();
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/CreateMinecraftArtifactsTask.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/CreateMinecraftArtifactsTask.java
@@ -3,16 +3,19 @@ package net.neoforged.moddevgradle.internal;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -64,6 +67,9 @@ abstract class CreateMinecraftArtifactsTask extends NeoFormRuntimeTask {
      */
     @OutputFile
     abstract RegularFileProperty getResourcesArtifact();
+
+    @OutputFiles
+    abstract MapProperty<String, File> getAdditionalResults();
 
     /**
      * Gradle dependency notation for the NeoForge userdev artifact.
@@ -156,6 +162,9 @@ abstract class CreateMinecraftArtifactsTask extends NeoFormRuntimeTask {
                 "--dist", "joined",
                 "--write-result", "clientResources:" + getResourcesArtifact().get().getAsFile().getAbsolutePath()
         );
+
+        getAdditionalResults().get().forEach((name, file) ->
+                Collections.addAll(args, "--write-result", name + ":" + file.getAbsolutePath()));
 
         // NOTE: When we use NeoForm standalone, the result-ids also change
         if (getNeoForgeArtifact().isPresent()) {

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -236,6 +236,7 @@ public class ModDevPlugin implements Plugin<Project> {
             task.getUseEclipseCompiler().set(nfrtSettings.getUseEclipseCompiler());
             task.getNeoForgeArtifact().set(getNeoForgeUserDevDependencyNotation(extension));
             task.getNeoFormArtifact().set(getNeoFormDataDependencyNotation(extension));
+            task.getAdditionalResults().set(nfrtSettings.getAdditionalResults());
 
             configureNfrtTask.accept(task);
         });

--- a/testproject/build.gradle
+++ b/testproject/build.gradle
@@ -64,6 +64,8 @@ neoForge {
         useEclipseCompiler = true
         // enableCache = false
         // verbose = true
+
+        additionalResults.put('vanillaDeobfuscated', project.file('build/vanilla.jar'))
     }
 
     parchment {


### PR DESCRIPTION
Allows pulling artifacts such as `vanillaDeobfuscated`

Fixes #107