### PR TITLE
Remove -1.x version suffix added by mistake

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,13 @@ base {
     archivesName = "moddev-gradle"
 }
 gradleutils.version {
-    branches.suffixBranch()
+    branches {
+        suffixBranch()
+        suffixExemptedBranches = ["main", "1.x"]
+    }
 }
 project.version = gradleutils.version
+logger.lifecycle("ModDevGradle version ${gradleutils.version}")
 
 changelog {
     from '0.1'


### PR DESCRIPTION
And let's also log the version because that is generally useful to know.