### PR TITLE
Disable Emojis in Eclipse by default since the console encoding is inconsistent

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/NeoFormRuntimeTask.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/NeoFormRuntimeTask.java
@@ -109,8 +109,8 @@ abstract public class NeoFormRuntimeTask extends DefaultTask {
             realArgs.add("--warn-on-artifact-manifest-miss");
         }
 
-        // When running through IJ or Eclipse, always enable emojis
-        if (IdeDetection.isIntelliJ() || IdeDetection.isEclipse()) {
+        // When running through IJ always enable emojis
+        if (IdeDetection.isIntelliJ()) {
             realArgs.add("--emojis");
         }
 


### PR DESCRIPTION
After fixing console output encoding, we still run into the problem that on the path from NFRT running underneath the Daemon -> IPC -> Gradle Client, the encoding gets messed up.
To be conservative, disable Emojis in Eclipse.

![image](https://github.com/user-attachments/assets/c5578d6a-92ea-432a-99cd-d36f6b7eea32)
