### PR TITLE
Fix createLaunchScript tasks compiling dependent projects in some cases

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/CreateLaunchScriptTask.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/CreateLaunchScriptTask.java
@@ -11,11 +11,12 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
@@ -61,8 +62,8 @@ abstract class CreateLaunchScriptTask extends DefaultTask {
     /**
      * Set to the desired Java runtime classpath.
      */
-    @Classpath
     @InputFiles
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     abstract ConfigurableFileCollection getRuntimeClasspath();
 
     @Input

--- a/src/main/java/net/neoforged/moddevgradle/internal/CreateLaunchScriptTask.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/CreateLaunchScriptTask.java
@@ -63,7 +63,7 @@ abstract class CreateLaunchScriptTask extends DefaultTask {
      * Set to the desired Java runtime classpath.
      */
     @InputFiles
-    @PathSensitive(PathSensitivity.NAME_ONLY)
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     abstract ConfigurableFileCollection getRuntimeClasspath();
 
     @Input

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -442,7 +442,10 @@ public class ModDevPlugin implements Plugin<Project> {
                 task.setDescription("Creates a bash/shell-script to launch the " + run.getName() + " Minecraft run from outside Gradle or your IDE.");
 
                 task.getWorkingDirectory().set(run.getGameDirectory().map(d -> d.getAsFile().getAbsolutePath()));
-                task.getRuntimeClasspath().setFrom(runtimeClasspathConfig);
+                // Use a provider indirection to NOT capture a task dependency on the runtimeClasspath.
+                // Resolving the classpath could require compiling some code depending on the runtimeClasspath setup.
+                // We don't want to do that on IDE sync!
+                task.getRuntimeClasspath().setFrom(project.provider(() -> runtimeClasspathConfig.get().getFiles()));
                 task.getLaunchScript().set(RunUtils.getLaunchScript(modDevBuildDir, run));
                 task.getClasspathArgsFile().set(RunUtils.getArgFile(modDevBuildDir, run, RunUtils.RunArgFile.CLASSPATH));
                 task.getVmArgsFile().set(prepareRunTask.get().getVmArgsFile().map(d -> d.getAsFile().getAbsolutePath()));


### PR DESCRIPTION
I ran into that while testing NeoDev... When this happens, a compilation failure will cause the entire IDE sync to fail.

So this PR removes the dependency capture by using a `project.provider(() -> xxx.get())` indirection. Additionally, might as well change the task input to not be a classpath.