### PR TITLE
Don't run `tasksBefore` when syncing project

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -13,3 +13,5 @@ Nonetheless, every single breaking change is documented here, along with a sugge
   - To fix: Refer to the [README](README.md#publication-of-access-transformers) for documentation of the new syntax.
 - Parchment: Specifying only the Minecraft version or only the mapping version will now fail.
   - This is meant to catch usage mistakes.
+- `beforeRun` tasks do not run on IDE project sync anymore.
+  - To run a task on sync, use `neoForge.ideSyncTask <task>` 

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -422,7 +422,6 @@ public class ModDevPlugin implements Plugin<Project> {
                 task.getProgramArguments().set(run.getProgramArguments());
                 task.getJvmArguments().set(run.getJvmArguments());
                 task.getGameLogLevel().set(run.getLogLevel());
-                task.dependsOn(run.getTasksBefore());
             });
             prepareRunTasks.put(run, prepareRunTask);
             ideSyncTask.configure(task -> task.dependsOn(prepareRunTask));
@@ -472,6 +471,7 @@ public class ModDevPlugin implements Plugin<Project> {
                 task.args(RunUtils.getArgFileParameter(prepareRunTask.get().getProgramArgsFile().get()).replace("\\", "\\\\"));
                 // Of course we need the arg files to be up-to-date ;)
                 task.dependsOn(prepareRunTask);
+                task.dependsOn(run.getTasksBefore());
 
                 task.getJvmArgumentProviders().add(RunUtils.getGradleModFoldersProvider(project, run.getMods(), false));
             });


### PR DESCRIPTION
Fixes #146. Technically a breaking change?