### PR TITLE
Remove dependency and extendsFrom from ModModel DSL

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -15,3 +15,6 @@ Nonetheless, every single breaking change is documented here, along with a sugge
   - This is meant to catch usage mistakes.
 - Run `beforeTask`s do not run on IDE project sync anymore.
   - To run a task on sync, use `neoForge.ideSyncTask <task>`.
+- Removal of `dependency` and `extendsFrom` inside the `neoForge.mods {}` block.
+  - These functions generally do not work, and were removed to reduce confusion.
+  - `sourceSet <sourceSet>` should be used instead. If this is not sufficient, please open an issue.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -18,3 +18,5 @@ Nonetheless, every single breaking change is documented here, along with a sugge
 - Removal of `dependency` and `extendsFrom` inside the `neoForge.mods {}` block.
   - These functions generally do not work, and were removed to reduce confusion.
   - `sourceSet <sourceSet>` should be used instead. If this is not sufficient, please open an issue.
+- `mods` cannot contain the same source set multiple times.
+  - This is meant to catch usage mistakes.

--- a/src/main/java/net/neoforged/moddevgradle/dsl/InternalModelHelper.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/InternalModelHelper.java
@@ -13,10 +13,6 @@ public class InternalModelHelper {
     public InternalModelHelper() {
     }
 
-    public static Configuration getModConfiguration(ModModel modModel) {
-        return modModel.getConfiguration();
-    }
-
     public static String nameOfRun(RunModel run, @Nullable String prefix, @Nullable String suffix) {
         return StringUtils.uncapitalize((prefix == null ? "" : prefix)
                                         + StringUtils.capitalize(run.getName())

--- a/src/main/java/net/neoforged/moddevgradle/dsl/ModModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/ModModel.java
@@ -1,13 +1,8 @@
 package net.neoforged.moddevgradle.dsl;
 
-import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import org.gradle.api.Named;
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetContainer;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -16,12 +11,6 @@ import java.util.List;
  * Model of a mod. This tells the moddev plugin which classes and resources need to be combined to produce a valid mod.
  */
 public abstract class ModModel implements Named {
-    /**
-     * Created on-demand if the user wants to add content to this mod using cross-project references
-     * or just standard dependency notation.
-     */
-    private Configuration configuration;
-
     @Inject
     public ModModel() {
         // TODO: We could potentially do a bit of name validation
@@ -29,35 +18,11 @@ public abstract class ModModel implements Named {
         getModSourceSets().finalizeValueOnRead();
     }
 
-    @Inject
-    protected abstract Project getProject();
-
     @Override
     public abstract String getName();
 
-    Configuration getConfiguration() {
-        if (configuration == null) {
-            configuration = getProject().getConfigurations().create("neoForgeModContent" + StringUtils.capitalize(getName()), configuration -> {
-                configuration.setCanBeConsumed(false);
-                configuration.setCanBeResolved(true);
-            });
-        }
-        return configuration;
-    }
-
     // Do not name getSourceSets or it will conflict with project.sourceSets in scripts.
     public abstract ListProperty<SourceSet> getModSourceSets();
-    public void dependency(CharSequence dependencyNotation) {
-        getConfiguration().getDependencies().add(getProject().getDependencyFactory().create(dependencyNotation));
-    }
-
-    public void dependency(Project projectRef) {
-        getConfiguration().getDependencies().add(getProject().getDependencyFactory().create(projectRef));
-    }
-
-    public void extendsFrom(Configuration configuration) {
-        getConfiguration().extendsFrom(configuration);
-    }
 
     public void sourceSet(SourceSet sourceSet) {
         getModSourceSets().add(sourceSet);

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -294,7 +294,6 @@ final class RunUtils {
         return modsProvider.zip(testedModProvider, ((mods, testedMod) -> mods.stream()
                 .collect(Collectors.toMap(ModModel::getName, mod -> {
                     var modFolder = project.getObjects().newInstance(ModFolder.class);
-                    modFolder.getFolders().from(InternalModelHelper.getModConfiguration(mod));
 
                     var sourceSets = mod.getModSourceSets().get();
 

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -9,6 +9,7 @@ import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
 import net.neoforged.moddevgradle.internal.utils.IdeDetection;
 import net.neoforged.moddevgradle.internal.utils.OperatingSystem;
 import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
@@ -297,7 +298,11 @@ final class RunUtils {
 
                     var sourceSets = mod.getModSourceSets().get();
 
-                    for (var sourceSet : sourceSets) {
+                    for (int i = 0; i < sourceSets.size(); ++i) {
+                        var sourceSet = sourceSets.get(i);
+                        if (sourceSets.subList(0, i).contains(sourceSet)) {
+                            throw new InvalidUserCodeException("Duplicate source set '%s' in mod '%s'".formatted(sourceSet.getName(), mod.getName()));
+                        }
                         outputFolderResolver.accept(sourceSet, modFolder.getFolders());
                     }
 

--- a/testproject/build.gradle
+++ b/testproject/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
+evaluationDependsOn(":subproject") // Because of the sourceset reference
+
 sourceSets {
     api
 }
@@ -52,7 +54,7 @@ neoForge {
         testproject {
             sourceSet sourceSets.main
             sourceSet sourceSets.api
-            dependency project(":subproject")
+            sourceSet project(":subproject").sourceSets.main
         }
     }
 

--- a/testproject/coremod/build.gradle
+++ b/testproject/coremod/build.gradle
@@ -11,7 +11,8 @@ java {
 jar {
     manifest {
         attributes([
-                "FMLModType": "LIBRARY"
+                "FMLModType": "LIBRARY",
+                "Automatic-Module-Name": "testproject.coremod"
         ])
     }
 }

--- a/testproject/coremod/src/main/resources/META-INF/MANIFEST.MF
+++ b/testproject/coremod/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+FMLModType: LIBRARY

--- a/testproject/coremod/src/main/resources/META-INF/MANIFEST.MF
+++ b/testproject/coremod/src/main/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,2 @@
 FMLModType: LIBRARY
+Automatic-Module-Name: testproject.coremod

--- a/testproject/jijtest/build.gradle
+++ b/testproject/jijtest/build.gradle
@@ -2,7 +2,11 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
+evaluationDependsOn(":coremod") // Because of the sourceset reference
+
 dependencies {
+    implementation project(":coremod")
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     jarJar(project(":coremod"))
@@ -33,7 +37,7 @@ neoForge {
             sourceSet sourceSets.main
         }
         coremod {
-            dependency project(":coremod")
+            sourceSet project(":coremod").sourceSets.main
         }
     }
 


### PR DESCRIPTION
Fixes #119.

Removed because they do not work in IDEs. Even worse, sometimes they might appear to work! For example, before this PR, `gradlew :jijtest:runData` on the testproject works. Now, if you run Data from the IDE it will works because the jar file got built. However, if you remove `coremod/build/libs/coremod.jar` and try running with the IDE again... then it fails!