### PR TITLE
Add UnitTest#getLoadedMods() to configure which mods are loaded in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ neoForge {
         // This allows NeoForge to load the test/ classes and resources as belonging to the mod.
         testedMod = mods.<mod name > // <mod name> must match the name in the mods { } block.
         // Configure which mods are loaded in the test environment, if the default (all declared mods) is not appropriate.
-        // This should include testedMod, and can include other mods as well.
+        // This must contain testedMod, and can include other mods as well.
         // loadedMods = [mods.<mod name >, mods.<mod name 2>]
     }
 }

--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ neoForge {
         // Configure which mod is being tested.
         // This allows NeoForge to load the test/ classes and resources as belonging to the mod.
         testedMod = mods.<mod name > // <mod name> must match the name in the mods { } block.
+        // Configure which mods are loaded in the test environment, if the default (all declared mods) is not appropriate.
+        // This should include testedMod, and can include other mods as well.
+        // loadedMods = [mods.<mod name >, mods.<mod name 2>]
     }
 }
 ```

--- a/src/main/java/net/neoforged/moddevgradle/dsl/NeoForgeExtension.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/NeoForgeExtension.java
@@ -41,6 +41,7 @@ public abstract class NeoForgeExtension {
         this.accessTransformers = accessTransformers;
         this.interfaceInjectionData = interfaceInjectionData;
         getValidateAccessTransformers().convention(false);
+        unitTest.getLoadedMods().convention(getMods());
     }
 
     /**

--- a/src/main/java/net/neoforged/moddevgradle/dsl/UnitTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/UnitTest.java
@@ -34,7 +34,7 @@ public abstract class UnitTest {
 
     /**
      * The mods to load when running unit tests. Defaults to all mods registered in the project.
-     * This should include {@link #getTestedMod()}.
+     * This must contain {@link #getTestedMod()}.
      *
      * @see ModModel
      */

--- a/src/main/java/net/neoforged/moddevgradle/dsl/UnitTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/UnitTest.java
@@ -3,6 +3,7 @@ package net.neoforged.moddevgradle.dsl;
 import net.neoforged.moddevgradle.internal.ModDevPlugin;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 
@@ -30,4 +31,12 @@ public abstract class UnitTest {
      * will be added to that mod at runtime.
      */
     public abstract Property<ModModel> getTestedMod();
+
+    /**
+     * The mods to load when running unit tests. Defaults to all mods registered in the project.
+     * This should include {@link #getTestedMod()}.
+     *
+     * @see ModModel
+     */
+    public abstract SetProperty<ModModel> getLoadedMods();
 }

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -724,7 +724,7 @@ public class ModDevPlugin implements Plugin<Project> {
             task.systemProperty("fml.junit.argsfile", programArgsFile.get().getAsFile().getAbsolutePath());
             task.jvmArgs(RunUtils.getArgFileParameter(vmArgsFile.get()));
 
-            var modFoldersProvider = RunUtils.getGradleModFoldersProvider(project, project.provider(extension::getMods), true);
+            var modFoldersProvider = RunUtils.getGradleModFoldersProvider(project, unitTest.getLoadedMods(), true);
             task.getJvmArgumentProviders().add(modFoldersProvider);
         });
 
@@ -736,7 +736,7 @@ public class ModDevPlugin implements Plugin<Project> {
             // For JUnit we have to write this to a separate file due to the Run parameters being shared among all projects.
             var intellijVmArgsFile = runArgsDir.map(dir -> dir.file("intellijVmArgs.txt"));
             var outputDirectory = RunUtils.getIntellijOutputDirectory(project);
-            var ideSpecificVmArgs = RunUtils.escapeJvmArg(RunUtils.getIdeaModFoldersProvider(project, outputDirectory, unitTest.getTestedMod().map(Set::of), true).getArgument());
+            var ideSpecificVmArgs = RunUtils.escapeJvmArg(RunUtils.getIdeaModFoldersProvider(project, outputDirectory, unitTest.getLoadedMods(), true).getArgument());
             try {
                 var vmArgsFilePath = intellijVmArgsFile.get().getAsFile().toPath();
                 Files.createDirectories(vmArgsFilePath.getParent());

--- a/testproject/jijtest/build.gradle
+++ b/testproject/jijtest/build.gradle
@@ -44,5 +44,6 @@ neoForge {
     unitTest {
         enable()
         testedMod = mods.jijtest
+        loadedMods = [mods.coremod]
     }
 }

--- a/testproject/jijtest/build.gradle
+++ b/testproject/jijtest/build.gradle
@@ -44,6 +44,5 @@ neoForge {
     unitTest {
         enable()
         testedMod = mods.jijtest
-        loadedMods = [mods.coremod]
     }
 }


### PR DESCRIPTION
Runs can already choose exactly which mods to load, but unit tests cannot. This PR fixes this. The method is called `getLoadedMods()` to ensure that `mods.<name>` continues to work as expected; I wish we had also named the `RunModel` method like that, but unfortunately it is too late.