### PR TITLE
Deprecate RunModel#getMods in favor of getLoadedMods

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
@@ -9,6 +9,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.Dependencies;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -29,6 +30,7 @@ import java.util.regex.Pattern;
 public abstract class RunModel implements Named, Dependencies {
     private static final Pattern VALID_RUN_NAME = Pattern.compile("[a-zA-Z][\\w-]*");
 
+    private final Logger logger;
     private final String name;
 
     private final Configuration configuration;
@@ -40,12 +42,13 @@ public abstract class RunModel implements Named, Dependencies {
 
     @Inject
     public RunModel(String name, Project project) {
+        this.logger = project.getLogger();
         this.name = name;
         if (!VALID_RUN_NAME.matcher(name).matches()) {
             throw new GradleException("Run name '" + name + "' is invalid! It must match " + VALID_RUN_NAME.pattern());
         }
 
-        getMods().convention(project.getExtensions().getByType(NeoForgeExtension.class).getMods());
+        getLoadedMods().convention(project.getExtensions().getByType(NeoForgeExtension.class).getMods());
 
         getGameDirectory().convention(project.getLayout().getProjectDirectory().dir("run"));
 
@@ -140,7 +143,16 @@ public abstract class RunModel implements Named, Dependencies {
      *
      * @see ModModel
      */
-    public abstract SetProperty<ModModel> getMods();
+    public abstract SetProperty<ModModel> getLoadedMods();
+
+    /**
+     * @deprecated This method conflicts with {@link NeoForgeExtension#getMods()}. Use {@link #getLoadedMods()} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public SetProperty<ModModel> getMods() {
+        logger.error("RunModel#getMods() is deprecated and will be removed in ModDevGradle 3. Use RunModel#getLoadedMods() instead.");
+        return getLoadedMods();
+    }
 
     /**
      * Sets the run configuration type from NeoForge that should be used.

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -452,7 +452,7 @@ public class ModDevPlugin implements Plugin<Project> {
                 task.getVmArgsFile().set(prepareRunTask.get().getVmArgsFile().map(d -> d.getAsFile().getAbsolutePath()));
                 task.getProgramArgsFile().set(prepareRunTask.get().getProgramArgsFile().map(d -> d.getAsFile().getAbsolutePath()));
                 task.getEnvironment().set(run.getEnvironment());
-                task.getModFolders().set(RunUtils.getGradleModFoldersProvider(project, run.getMods(), false));
+                task.getModFolders().set(RunUtils.getGradleModFoldersProvider(project, run.getLoadedMods(), false));
             });
             ideSyncTask.configure(task -> task.dependsOn(createLaunchScriptTask));
 
@@ -476,7 +476,7 @@ public class ModDevPlugin implements Plugin<Project> {
                 task.dependsOn(prepareRunTask);
                 task.dependsOn(run.getTasksBefore());
 
-                task.getJvmArgumentProviders().add(RunUtils.getGradleModFoldersProvider(project, run.getMods(), false));
+                task.getJvmArgumentProviders().add(RunUtils.getGradleModFoldersProvider(project, run.getLoadedMods(), false));
             });
         });
 
@@ -832,7 +832,7 @@ public class ModDevPlugin implements Plugin<Project> {
         appRun.setJvmArgs(
                 RunUtils.escapeJvmArg(RunUtils.getArgFileParameter(prepareTask.getVmArgsFile().get()))
                 + " "
-                + RunUtils.escapeJvmArg(RunUtils.getIdeaModFoldersProvider(project, outputDirectory, run.getMods(), false).getArgument())
+                + RunUtils.escapeJvmArg(RunUtils.getIdeaModFoldersProvider(project, outputDirectory, run.getLoadedMods(), false).getArgument())
         );
         appRun.setMainClass(RunUtils.DEV_LAUNCH_MAIN_CLASS);
         appRun.setProgramParameters(RunUtils.escapeJvmArg(RunUtils.getArgFileParameter(prepareTask.getProgramArgsFile().get())));
@@ -1047,7 +1047,7 @@ public class ModDevPlugin implements Plugin<Project> {
         var config = JavaApplicationLaunchConfig.builder(eclipseProjectName)
                 .vmArgs(
                         RunUtils.escapeJvmArg(RunUtils.getArgFileParameter(prepareTask.getVmArgsFile().get())),
-                        RunUtils.escapeJvmArg(RunUtils.getEclipseModFoldersProvider(project, run.getMods(), false).getArgument())
+                        RunUtils.escapeJvmArg(RunUtils.getEclipseModFoldersProvider(project, run.getLoadedMods(), false).getArgument())
                 )
                 .args(RunUtils.escapeJvmArg(RunUtils.getArgFileParameter(prepareTask.getProgramArgsFile().get())))
                 .envVar(run.getEnvironment().get())
@@ -1082,7 +1082,7 @@ public class ModDevPlugin implements Plugin<Project> {
                 .withProjectName(eclipseProjectName)
                 .withArguments(List.of(RunUtils.getArgFileParameter(prepareTask.getProgramArgsFile().get())))
                 .withAdditionalJvmArgs(List.of(RunUtils.getArgFileParameter(prepareTask.getVmArgsFile().get()),
-                        RunUtils.getEclipseModFoldersProvider(project, run.getMods(), false).getArgument()))
+                        RunUtils.getEclipseModFoldersProvider(project, run.getLoadedMods(), false).getArgument()))
                 .withMainClass(RunUtils.DEV_LAUNCH_MAIN_CLASS)
                 .withShortenCommandLine(ShortCmdBehaviour.NONE)
                 .withConsoleType(ConsoleType.INTERNAL_CONSOLE)


### PR DESCRIPTION
`RunModel#getMods` conflicts with `NeoForgeExtension#getMods`. This means that scripts typically have to write the following:
```gradle
runs {
    xxx {
        mods = [neoForge.mods.xxx, neoForge.mods.yyy, neoForge.mods.zzz]
    }
}
```

The following syntax will work once this PR is merged, and the deprecated method is removed (that will happen in MDG 3):
```gradle
runs {
    xxx {
        loadedMods = [mods.xxx, mods.yyy, mods.zzz]
    }
}
```