### PR TITLE
[1.x] Fix # in user supplied program arguments being ignored

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -58,7 +58,8 @@ final class RunUtils {
 
     public static String escapeJvmArg(String arg) {
         var escaped = arg.replace("\\", "\\\\").replace("\"", "\\\"");
-        if (escaped.contains(" ")) {
+        // # is used for line comments in arg files and should be quoted to avoid misinterpretation
+        if (escaped.contains(" ") || escaped.contains("#")) {
             return "\"" + escaped + "\"";
         }
         return escaped;


### PR DESCRIPTION
Program arguments containing # need to be quoted to avoid the # character from being interpreted as the start of a line comment.