### PR TITLE
Add method to register sync tasks to NeoDevFacade

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/NeoDevFacade.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/NeoDevFacade.java
@@ -67,4 +67,8 @@ public final class NeoDevFacade {
                 assetPropertiesFile
         );
     }
+
+    public static void runTaskOnProjectSync(Project project, Object task) {
+        IdeIntegration.of(project).runTaskOnProjectSync(task);
+    }
 }


### PR DESCRIPTION
I want to use it for `CreateMinecraftArtifacts`, but it could of course be generally useful.