### PR TITLE
Implement support for split datagen (MC 1.21.4+)

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
@@ -157,7 +157,20 @@ public abstract class RunModel implements Named, Dependencies {
     }
 
     /**
+     * Equivalent to setting {@code type = "clientData"}.
+     *
+     * <p>Should only be used for Minecraft versions starting from 1.21.4.
+     * (The first snapshot that supports this is 24w45a).
+     */
+    public void clientData() {
+        getType().set("clientData");
+    }
+
+    /**
      * Equivalent to setting {@code type = "data"}.
+     *
+     * <p>Should only be used for Minecraft versions up to 1.21.3 included.
+     * (The last snapshot that supports this is 24w44a).
      */
     public void data() {
         getType().set("data");
@@ -168,6 +181,16 @@ public abstract class RunModel implements Named, Dependencies {
      */
     public void server() {
         getType().set("server");
+    }
+
+    /**
+     * Equivalent to setting {@code type = "serverData"}.
+     *
+     * <p>Should only be used for Minecraft versions starting from 1.21.4.
+     * (The first snapshot that supports this is 24w45a).
+     */
+    public void serverData() {
+        getType().set("serverData");
     }
 
     /**

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -553,7 +553,7 @@ public class ModDevPlugin implements Plugin<Project> {
             spec.shouldResolveConsistentlyWith(runtimeClasspathConfig.get());
             spec.attributes(attributes -> {
                 attributes.attributeProvider(MinecraftDistribution.ATTRIBUTE, type.map(t -> {
-                    var name = t.equals("client") || t.equals("data") ? MinecraftDistribution.CLIENT : MinecraftDistribution.SERVER;
+                    var name = t.equals("client") || t.equals("data") || t.equals("clientData") ? MinecraftDistribution.CLIENT : MinecraftDistribution.SERVER;
                     return project.getObjects().named(MinecraftDistribution.class, name);
                 }));
                 setNamedAttribute(project, attributes, Usage.USAGE_ATTRIBUTE, Usage.JAVA_RUNTIME);

--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
@@ -154,7 +154,14 @@ abstract class PrepareRunOrTest extends DefaultTask {
                 "server", new UserDevRunType(
                         true, "net.minecraft.server.Main", commonArgs, List.of(), false, true, false, false, Map.of(), Map.of()
                 ),
+                // TODO: find a way to check for Minecraft version?
                 "data", new UserDevRunType(
+                        true, "net.minecraft.data.Main", commonArgs, List.of(), false, false, true, false, Map.of(), Map.of()
+                ),
+                "clientData", new UserDevRunType(
+                        true, "net.minecraft.client.data.Main", commonArgs, List.of(), false, false, true, false, Map.of(), Map.of()
+                ),
+                "serverData", new UserDevRunType(
                         true, "net.minecraft.data.Main", commonArgs, List.of(), false, false, true, false, Map.of(), Map.of()
                 )
         ));


### PR DESCRIPTION
Do we want to enforce that `data()` is not used for versions with split datagen? I don't think we can parse MC snapshot versions with full reliability (e.g. do combat test snapshots not have a custom versioning scheme?).