### PR TITLE
Fix DevLaunch being unable to access the BSL main method for BSL 1.0 and below

### DIFF
--- a/src/legacy/java/net/neoforged/moddevgradle/internal/LegacyForgeFacade.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/internal/LegacyForgeFacade.java
@@ -7,5 +7,8 @@ public class LegacyForgeFacade {
     public static void configureRun(Project project, RunModel run) {
         // This will explicitly be replaced in RunUtils to make this work for IDEs
         run.getEnvironment().put("MOD_CLASSES", RunUtils.getGradleModFoldersProvider(project, run.getLoadedMods(), null).getClassesArgument());
+
+        // Old BSL versions before 2022 (i.e. on 1.18.2) did not export any packages, causing DevLaunch to be unable to access the main method
+        run.getJvmArguments().addAll("--add-exports", "cpw.mods.bootstraplauncher/cpw.mods.bootstraplauncher=ALL-UNNAMED");
     }
 }


### PR DESCRIPTION
Fixes this error on 1.18.2:

```
Caused by: java.lang.IllegalAccessException: class net.neoforged.devlaunch.Main cannot access class cpw.mods.bootstraplauncher.BootstrapLauncher (in module cpw.mods.bootstraplauncher) because module cpw.mods.bootstraplauncher does not export cpw.mods.bootstraplauncher to unnamed module @255316f2
```