### PR TITLE
Fix JarInJar of project dependencies by simultaneously publishing both jars (but not to Maven)

### DIFF
--- a/legacytest/forge/build.gradle
+++ b/legacytest/forge/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     modCompileOnly('mezz.jei:jei-1.20.1-forge:15.17.0.76')
     modRuntimeOnly('curse.maven:mekanism-268560:5662583')
     modImplementation('curse.maven:applied-energistics-2-223794:5641282')
+    jarJar('curse.maven:applied-energistics-2-223794:5641282')
+    jarJar(project(':nonmc'))
 }
 
 legacyForge {

--- a/legacytest/forge/src/main/java/mymod/MyMod.java
+++ b/legacytest/forge/src/main/java/mymod/MyMod.java
@@ -1,9 +1,11 @@
 package mymod;
 
+import net.minecraft.DetectedVersion;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod("mymod")
 public class MyMod {
     public void run() {
+        DetectedVersion.tryDetectVersion();
     }
 }

--- a/legacytest/forgedownstream/build.gradle
+++ b/legacytest/forgedownstream/build.gradle
@@ -1,0 +1,62 @@
+import java.util.jar.JarFile
+
+plugins {
+    id 'net.neoforged.moddev.legacyforge'
+}
+
+configurations {
+    upstream {
+        transitive = false
+    }
+}
+
+dependencies {
+    jarJar(project(":forge"))
+    upstream(project(":forge"))
+}
+
+legacyForge {
+    version = '1.20.1-47.3.0'
+}
+
+var copyJarJar = tasks.register('copyJarJar', Copy) {
+    from(configurations.jarJar)
+    destinationDir = file("build/jarjartest")
+    Action<Copy> checkAction = task -> {
+        var content = task.destinationDir.listFiles()
+        if (content.length != 1) {
+            throw new GradleException("Expected a single file to resolve from jarJar, but got: " + content)
+        }
+        new JarFile(content[0]).withCloseable { jarFile ->
+            var s = new String(jarFile.getInputStream(jarFile.getEntry("mymod/MyMod.class")).readAllBytes(), "ASCII")
+            s = s.replaceAll("[^a-zA-Z0-9/._-]+", " ")
+            if (!s.contains("m_195834_") || s.contains("tryDetectVersion")) {
+                throw new GradleException("Expected the remapped method on DetectedVersion to be called: " + s)
+            }
+        }
+    }
+    doLast checkAction
+    outputs.upToDateWhen { false }
+}
+build.dependsOn copyJarJar
+
+var copyUpstream = tasks.register('copyUpstream', Copy) {
+    from(configurations.upstream)
+    destinationDir = file("build/upstreamtest")
+    Action<Copy> checkAction = task -> {
+        var content = task.destinationDir.listFiles()
+        if (content.length != 1) {
+            throw new GradleException("Expected a single file to resolve from upstream, but got: " + content)
+        }
+        new JarFile(content[0]).withCloseable { jarFile ->
+            var s = new String(jarFile.getInputStream(jarFile.getEntry("mymod/MyMod.class")).readAllBytes(), "ASCII")
+            s = s.replaceAll("[^a-zA-Z0-9/.-]", " ")
+            if (s.contains("m_195834_") || !s.contains("tryDetectVersion")) {
+                throw new GradleException("Expected the unremapped method on DetectedVersion to be called " + s)
+            }
+        }
+    }
+    doLast checkAction
+    outputs.upToDateWhen { false }
+}
+build.dependsOn copyUpstream

--- a/legacytest/nonmc/build.gradle
+++ b/legacytest/nonmc/build.gradle
@@ -1,0 +1,12 @@
+
+plugins {
+    id 'java-library'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+group = "mdgtest"

--- a/legacytest/settings.gradle
+++ b/legacytest/settings.gradle
@@ -6,3 +6,5 @@ plugins {
 includeBuild '..'
 
 include 'forge'
+include 'forgedownstream'
+include 'nonmc'

--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/MappingsDisambiguationRule.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/MappingsDisambiguationRule.java
@@ -1,0 +1,19 @@
+package net.neoforged.moddevgradle.legacyforge.internal;
+
+import org.gradle.api.attributes.AttributeDisambiguationRule;
+import org.gradle.api.attributes.MultipleCandidatesDetails;
+
+/**
+ * This disambiguation rule will prefer NAMED over SRG when both are present.
+ */
+class MappingsDisambiguationRule implements AttributeDisambiguationRule<MinecraftMappings> {
+    @Override
+    public void execute(MultipleCandidatesDetails<MinecraftMappings> details) {
+        var consumerValue = details.getConsumerValue();
+        if (consumerValue == null) {
+            if (details.getCandidateValues().contains(MinecraftMappings.NAMED)) {
+                details.closestMatch(MinecraftMappings.NAMED);
+            }
+        }
+    }
+}

--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/MinecraftMappings.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/MinecraftMappings.java
@@ -1,0 +1,20 @@
+package net.neoforged.moddevgradle.legacyforge.internal;
+
+import org.gradle.api.Named;
+import org.gradle.api.attributes.Attribute;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Locale;
+
+@ApiStatus.Internal
+public enum MinecraftMappings implements Named {
+    NAMED,
+    SRG;
+
+    public static final Attribute<MinecraftMappings> ATTRIBUTE = Attribute.of("net.neoforged.moddevgradle.legacy.minecraft_mappings", MinecraftMappings.class);
+
+    @Override
+    public String getName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarArtifacts.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarArtifacts.java
@@ -22,6 +22,8 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class JarJarArtifacts {
+    private static final Logger LOG = LoggerFactory.getLogger(JarJarArtifacts.class);
     private transient final SetProperty<ResolvedComponentResult> includedRootComponents;
     private transient final SetProperty<ResolvedArtifactResult> includedArtifacts;
 
@@ -93,6 +96,7 @@ public abstract class JarJarArtifacts {
         var data = new ArrayList<ResolvedJarJarArtifact>();
         var filesAdded = new HashSet<String>();
         for (ResolvedArtifactResult result : artifacts) {
+            LOG.debug("About to embed artifact {} ({})", result, result.getFile().getAbsolutePath());
             ResolvedVariantResult variant = result.getVariant();
 
             ArtifactIdentifier artifactIdentifier = capabilityOrModule(variant);

--- a/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/jarjar/JarJarPlugin.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.ApiStatus;
 public class JarJarPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        SourceSetContainer sourceSets = ExtensionUtils.getExtension(project, "sourceSets", SourceSetContainer.class);
+        var sourceSets = ExtensionUtils.getSourceSets(project);
         sourceSets.all(sourceSet -> {
             var jarJarTask = JarJar.registerWithConfiguration(project, sourceSet.getTaskName(null, "jarJar"));
             jarJarTask.configure(task -> task.setGroup(Branding.MDG.internalTaskGroup()));


### PR DESCRIPTION
Fixes:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':antimatter-forge:jarJar'.
> Error while evaluating property 'jarJarArtifacts.resolvedArtifacts' of task ':antimatter-forge:jarJar'.
   > Failed to query the value of task ':antimatter-forge:jarJar' property 'jarJarArtifacts' property 'resolvedArtifacts'.
      > Trying to add multiple files at the same embedded location: org.gt-reimagined.TesseractAPI-forge-0.2.4-1.18.2.jar
```