### PR TITLE
Fix forge version parsing failing on legacy

### DIFF
--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
@@ -35,6 +35,9 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        // Workaround to get moddev plugin to pick correct version parser
+        project.getExtensions().getExtraProperties().set("legacy_hack_marker", true);
+
         project.getPlugins().apply(ModDevPlugin.class);
 
         project.getRepositories().maven(repo -> {

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -153,7 +153,8 @@ public class ModDevPlugin implements Plugin<Project> {
         ideIntegration.runTaskOnProjectSync(extension.getIdeSyncTasks());
         var dependencyFactory = project.getDependencyFactory();
 
-        Provider<VersionCapabilities> versionCapabilities = extension.getVersion().map(VersionCapabilities::ofNeoForgeVersion)
+        boolean isLegacy = project.getExtensions().getExtraProperties().has("legacy_hack_marker");
+        Provider<VersionCapabilities> versionCapabilities = extension.getVersion().map(!isLegacy ? VersionCapabilities::ofNeoForgeVersion : VersionCapabilities::ofForgeVersion)
                 .orElse(extension.getNeoFormVersion().map(VersionCapabilities::ofNeoFormVersion))
                 .orElse(VersionCapabilities.latest());
 


### PR DESCRIPTION
A hack workaround to solve the main MDG plugin parsing the version incorrectly when legacy is applied.