### PR TITLE
Fix version parser not ignoring the patch component of a Minecraft version if it is zero

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/VersionCapabilities.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/VersionCapabilities.java
@@ -67,7 +67,13 @@ public record VersionCapabilities(int javaVersion, boolean splitDataRuns) implem
         if (!matcher.matches()) {
             return -1;
         }
-        return MinecraftVersionList.VERSIONS.indexOf("1." + matcher.group(1));
+
+        var mcVersion = "1." + matcher.group(1);
+        // Versions such as 21.0.0 are for Minecraft 1.21 and NOT 1.21.0, therefore we strip the trailing .0
+        if (mcVersion.endsWith(".0")) {
+            mcVersion = mcVersion.substring(0, mcVersion.length() - 2);
+        }
+        return MinecraftVersionList.VERSIONS.indexOf(mcVersion);
     }
 
     public static VersionCapabilities ofNeoForgeVersion(String version) {

--- a/src/test/java/net/neoforged/moddevgradle/internal/utils/VersionCapabilitiesTest.java
+++ b/src/test/java/net/neoforged/moddevgradle/internal/utils/VersionCapabilitiesTest.java
@@ -36,6 +36,7 @@ public class VersionCapabilitiesTest {
 
     @ParameterizedTest()
     @CsvSource({
+            "21.0.3-beta,1.21",
             "21.4.8-beta,1.21.4",
             "21.4.10-beta-pr-1744-gh-1582,1.21.4",
             "21.4.10,1.21.4",


### PR DESCRIPTION
NeoForge `21.0.3-beta` would be identified as being for Minecraft 1.21**.0** not 1.21