### PR TITLE
Redownload Assets if the referenced asset files have gone missing

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/PrepareRunOrTest.java
@@ -15,6 +15,7 @@ import net.neoforged.moddevgradle.internal.utils.FileUtils;
 import net.neoforged.moddevgradle.internal.utils.OperatingSystem;
 import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import net.neoforged.moddevgradle.internal.utils.VersionCapabilitiesInternal;
+import net.neoforged.nfrtgradle.DownloadedAssetsReference;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -274,7 +275,7 @@ abstract class PrepareRunOrTest extends DefaultTask {
         }
 
         lines.add("# NeoForge Run-Type Program Arguments");
-        var assetProperties = RunUtils.loadAssetProperties(getAssetProperties().get().getAsFile());
+        var assetProperties = DownloadedAssetsReference.loadProperties(getAssetProperties().get().getAsFile());
         List<String> args = runConfig.args();
         for (String arg : args) {
             switch (arg) {

--- a/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/RunUtils.java
@@ -1,17 +1,13 @@
 package net.neoforged.moddevgradle.internal;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -60,25 +56,6 @@ final class RunUtils {
         return runModel.getType().orElse(project.getProviders().provider(() -> {
             throw new GradleException("The run '" + runModel.getName() + "' did not specify a type property");
         }));
-    }
-
-    public static AssetProperties loadAssetProperties(File file) {
-        Properties assetProperties = new Properties();
-        try (var input = new BufferedInputStream(new FileInputStream(file))) {
-            assetProperties.load(input);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to load asset properties", e);
-        }
-        if (!assetProperties.containsKey("assets_root")) {
-            throw new IllegalStateException("Asset properties file does not contain assets_root");
-        }
-        if (!assetProperties.containsKey("asset_index")) {
-            throw new IllegalStateException("Asset properties file does not contain asset_index");
-        }
-
-        return new AssetProperties(
-                assetProperties.getProperty("asset_index"),
-                assetProperties.getProperty("assets_root"));
     }
 
     public static void writeLog4j2Configuration(Level rootLevel, Path destination) throws IOException {
@@ -289,8 +266,6 @@ final class RunUtils {
         }));
     }
 }
-
-record AssetProperties(String assetIndex, String assetsRoot) {}
 
 abstract class ModFoldersProvider implements CommandLineArgumentProvider {
     @Inject

--- a/src/main/java/net/neoforged/nfrtgradle/DownloadedAssetsReference.java
+++ b/src/main/java/net/neoforged/nfrtgradle/DownloadedAssetsReference.java
@@ -1,0 +1,29 @@
+package net.neoforged.nfrtgradle;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
+public record DownloadedAssetsReference(String assetIndex, String assetsRoot) {
+    public static DownloadedAssetsReference loadProperties(File file) {
+        Properties assetProperties = new Properties();
+        try (var input = new BufferedInputStream(new FileInputStream(file))) {
+            assetProperties.load(input);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load asset properties", e);
+        }
+        if (!assetProperties.containsKey("assets_root")) {
+            throw new IllegalStateException("Asset properties file does not contain assets_root");
+        }
+        if (!assetProperties.containsKey("asset_index")) {
+            throw new IllegalStateException("Asset properties file does not contain asset_index");
+        }
+
+        return new DownloadedAssetsReference(
+                assetProperties.getProperty("asset_index"),
+                assetProperties.getProperty("assets_root"));
+    }
+}


### PR DESCRIPTION
When the gradle cache is deleted (or whereever the assets are); but the project directory is not, MDG will not re-download the assets since it doesn't know they've gone missing.
This code adds an up-to-date check to the DownloadAssets task that validates if the assets directory still exists.