### PR TITLE
[WIP] Lazily configure dependency configurations

### DIFF
--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
@@ -85,14 +85,14 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
         project.getDependencies().getComponents().withModule("net.neoforged:minecraft-dependencies", NonStrictDependencyTransform.class);
 
         var depFactory = project.getDependencyFactory();
-        var autoRenamingToolRuntime = project.getConfigurations().create(CONFIGURATION_TOOL_ART, spec -> {
+        var autoRenamingToolRuntime = project.getConfigurations().register(CONFIGURATION_TOOL_ART, spec -> {
             spec.setDescription("The AutoRenamingTool CLI tool");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
             spec.setTransitive(false);
             spec.getDependencies().add(depFactory.create("net.neoforged:AutoRenamingTool:2.0.4:all"));
         });
-        var installerToolsRuntime = project.getConfigurations().create(CONFIGURATION_TOOL_INSTALLERTOOLS, spec -> {
+        var installerToolsRuntime = project.getConfigurations().register(CONFIGURATION_TOOL_INSTALLERTOOLS, spec -> {
             spec.setDescription("The InstallerTools CLI tool");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
@@ -198,15 +198,17 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
         project.getTasks().named("assemble", assemble -> assemble.dependsOn(reobfJar));
 
         // Forge expects the mapping csv files on the root classpath
-        artifacts.runtimeDependencies()
-                .getDependencies().add(project.getDependencyFactory().create(project.files(mappingsCsv)));
+        artifacts.runtimeDependencies().configure(c -> {
+            c.getDependencies().add(project.getDependencyFactory().create(project.files(mappingsCsv)));
+        });
 
-        var remapDeps = project.getConfigurations().create("remappingDependencies", spec -> {
+        var remapDeps = project.getConfigurations().register("remappingDependencies", spec -> {
             spec.setDescription("An internal configuration that contains the Minecraft dependencies, used for remapping mods");
             spec.setCanBeConsumed(false);
             spec.setCanBeDeclared(false);
             spec.setCanBeResolved(true);
-            spec.extendsFrom(artifacts.runtimeDependencies());
+            // TODO: is there no better way?
+            spec.extendsFrom(artifacts.runtimeDependencies().get());
         });
 
         project.getDependencies().registerTransform(RemappingTransform.class, params -> {
@@ -244,13 +246,15 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
         var sourceSets = ExtensionUtils.getSourceSets(project);
         sourceSets.all(sourceSet -> {
             var configurationName = sourceSet.getTaskName(null, "jarJar");
-            project.getConfigurations().getByName(configurationName).withDependencies(dependencies -> {
-                dependencies.forEach(dep -> {
-                    if (dep instanceof ProjectDependency projectDependency) {
-                        projectDependency.attributes(a -> {
-                            a.attribute(MinecraftMappings.ATTRIBUTE, srgMappings);
-                        });
-                    }
+            project.getConfigurations().named(configurationName, c -> {
+                c.withDependencies(dependencies -> {
+                    dependencies.forEach(dep -> {
+                        if (dep instanceof ProjectDependency projectDependency) {
+                            projectDependency.attributes(a -> {
+                                a.attribute(MinecraftMappings.ATTRIBUTE, srgMappings);
+                            });
+                        }
+                    });
                 });
             });
         });
@@ -266,10 +270,10 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
         project.getDependencies().getArtifactTypes().create(ARTIFACT_TYPE_SRG_JAR, artifactType -> {
             artifactType.getAttributes().attribute(MinecraftMappings.ATTRIBUTE, srgMappings);
         });
-        obf.createRemappingConfiguration(project.getConfigurations().getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
-        obf.createRemappingConfiguration(project.getConfigurations().getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME));
-        obf.createRemappingConfiguration(project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
-        obf.createRemappingConfiguration(project.getConfigurations().getByName(JavaPlugin.API_CONFIGURATION_NAME));
-        obf.createRemappingConfiguration(project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME));
+        obf.registerRemappingConfiguration(project.getConfigurations().named(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+        obf.registerRemappingConfiguration(project.getConfigurations().named(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME));
+        obf.registerRemappingConfiguration(project.getConfigurations().named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
+        obf.registerRemappingConfiguration(project.getConfigurations().named(JavaPlugin.API_CONFIGURATION_NAME));
+        obf.registerRemappingConfiguration(project.getConfigurations().named(JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME));
     }
 }

--- a/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/RunModel.java
@@ -9,6 +9,7 @@ import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
 import net.neoforged.moddevgradle.internal.utils.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -31,7 +32,7 @@ public abstract class RunModel implements Named, Dependencies {
 
     private final String name;
 
-    private final Configuration configuration;
+    private final NamedDomainObjectProvider<Configuration> configuration;
 
     /**
      * The Gradle tasks that should be run before running this run.
@@ -49,7 +50,7 @@ public abstract class RunModel implements Named, Dependencies {
 
         getGameDirectory().convention(project.getLayout().getProjectDirectory().dir("run"));
 
-        configuration = project.getConfigurations().create(InternalModelHelper.nameOfRun(this, "", "additionalRuntimeClasspath"), configuration -> {
+        configuration = project.getConfigurations().register(InternalModelHelper.nameOfRun(this, "", "additionalRuntimeClasspath"), configuration -> {
             configuration.setCanBeResolved(false);
             configuration.setCanBeConsumed(false);
         });
@@ -235,7 +236,7 @@ public abstract class RunModel implements Named, Dependencies {
     }
 
     public Configuration getAdditionalRuntimeClasspathConfiguration() {
-        return configuration;
+        return configuration.get();
     }
 
     /**

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevArtifactsWorkflow.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevArtifactsWorkflow.java
@@ -14,6 +14,7 @@ import net.neoforged.nfrtgradle.DownloadAssets;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
@@ -45,8 +46,8 @@ public record ModDevArtifactsWorkflow(
         TaskProvider<CreateMinecraftArtifacts> createArtifacts,
         Provider<? extends Dependency> minecraftClassesDependency,
         TaskProvider<DownloadAssets> downloadAssets,
-        Configuration runtimeDependencies,
-        Configuration compileDependencies,
+        NamedDomainObjectProvider<Configuration> runtimeDependencies,
+        NamedDomainObjectProvider<Configuration> compileDependencies,
         Provider<Directory> modDevBuildDir,
         Provider<Directory> artifactsBuildDir) {
 
@@ -102,7 +103,7 @@ public record ModDevArtifactsWorkflow(
         }
 
         var parchment = extension.getParchment();
-        var parchmentData = configurations.create("parchmentData", spec -> {
+        var parchmentData = configurations.register("parchmentData", spec -> {
             spec.setDescription("Data used to add parameter names and javadoc to Minecraft sources");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -168,7 +169,7 @@ public record ModDevArtifactsWorkflow(
 
         // Name of the configuration in which we place the required dependencies to develop mods for use in the runtime-classpath.
         // We cannot use "runtimeOnly", since the contents of that are published.
-        var runtimeDependencies = configurations.create("modDevRuntimeDependencies", config -> {
+        var runtimeDependencies = configurations.register("modDevRuntimeDependencies", config -> {
             config.setDescription("The runtime dependencies to develop a mod for, including Minecraft classes and modding platform classes.");
             config.setCanBeResolved(false);
             config.setCanBeConsumed(false);
@@ -182,7 +183,7 @@ public record ModDevArtifactsWorkflow(
 
         // Configuration in which we place the required dependencies to develop mods for use in the compile-classpath.
         // While compile only is not published, we also use a configuration here to be consistent.
-        var compileDependencies = configurations.create("modDevCompileDependencies", config -> {
+        var compileDependencies = configurations.register("modDevCompileDependencies", config -> {
             config.setDescription("The compile-time dependencies to develop a mod, including Minecraft and modding platform classes.");
             config.setCanBeResolved(false);
             config.setCanBeConsumed(false);
@@ -222,7 +223,7 @@ public record ModDevArtifactsWorkflow(
     /**
      * Collects all dependencies needed by the NeoFormRuntime
      */
-    private static List<Configuration> configureArtifactManifestConfigurations(
+    private static List<Provider<Configuration>> configureArtifactManifestConfigurations(
             Project project,
             @Nullable ModuleDependency moddingPlatformDependency,
             @Nullable ModuleDependency recompilableMinecraftWorkflowDependency) {
@@ -230,11 +231,11 @@ public record ModDevArtifactsWorkflow(
 
         var configurationPrefix = "neoFormRuntimeDependencies";
 
-        var result = new ArrayList<Configuration>();
+        var result = new ArrayList<Provider<Configuration>>();
 
         // Gradle prevents us from having dependencies with "incompatible attributes" in the same configuration.
         // What constitutes incompatible cannot be overridden on a per-configuration basis.
-        var neoForgeClassesAndData = configurations.create(configurationPrefix + "NeoForgeClasses", spec -> {
+        var neoForgeClassesAndData = configurations.register(configurationPrefix + "NeoForgeClasses", spec -> {
             spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (NeoForge classes)");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
@@ -252,7 +253,7 @@ public record ModDevArtifactsWorkflow(
         result.add(neoForgeClassesAndData);
 
         if (moddingPlatformDependency != null) {
-            var neoForgeSources = configurations.create(configurationPrefix + "NeoForgeSources", spec -> {
+            var neoForgeSources = configurations.register(configurationPrefix + "NeoForgeSources", spec -> {
                 spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (NeoForge sources)");
                 spec.setCanBeConsumed(false);
                 spec.setCanBeResolved(true);
@@ -267,7 +268,7 @@ public record ModDevArtifactsWorkflow(
 
         // Compile-time dependencies used by NeoForm, NeoForge and Minecraft.
         // Also includes any classes referenced by compiled Minecraft code (used by decompilers, renamers, etc.)
-        var compileClasspath = configurations.create(configurationPrefix + "CompileClasspath", spec -> {
+        var compileClasspath = configurations.register(configurationPrefix + "CompileClasspath", spec -> {
             spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (Classpath)");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
@@ -288,7 +289,7 @@ public record ModDevArtifactsWorkflow(
         result.add(compileClasspath);
 
         // Runtime-time dependencies used by NeoForm, NeoForge and Minecraft.
-        var runtimeClasspath = configurations.create(configurationPrefix + "RuntimeClasspath", spec -> {
+        var runtimeClasspath = configurations.register(configurationPrefix + "RuntimeClasspath", spec -> {
             spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (Classpath)");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
@@ -322,8 +323,9 @@ public record ModDevArtifactsWorkflow(
             throw new GradleException("Cannot add to the source set in another project: " + sourceSet);
         }
 
-        configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()).extendsFrom(runtimeDependencies);
-        configurations.getByName(sourceSet.getCompileClasspathConfigurationName()).extendsFrom(compileDependencies);
+        // TODO: no better way?
+        configurations.named(sourceSet.getRuntimeClasspathConfigurationName(), c -> c.extendsFrom(runtimeDependencies.get()));
+        configurations.named(sourceSet.getCompileClasspathConfigurationName(), c -> c.extendsFrom(compileDependencies.get()));
     }
 
     public Provider<RegularFile> requestAdditionalMinecraftArtifact(String id, String filename) {

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevRunWorkflow.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevRunWorkflow.java
@@ -18,6 +18,7 @@ import net.neoforged.nfrtgradle.DownloadAssets;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -59,8 +60,8 @@ public class ModDevRunWorkflow {
     @Nullable
     private final ModuleDependency testFixturesDependency;
     private final ModuleDependency gameLibrariesDependency;
-    private final Configuration additionalClasspath;
-    private final Configuration userDevConfigOnly;
+    private final NamedDomainObjectProvider<Configuration> additionalClasspath;
+    private final NamedDomainObjectProvider<Configuration> userDevConfigOnly;
 
     /**
      * @param gameLibrariesDependency A module dependency that represents the library dependencies of the game.
@@ -87,7 +88,7 @@ public class ModDevRunWorkflow {
 
         // Let's try to get the userdev JSON out of the universal jar
         // I don't like having to use a configuration for this...
-        userDevConfigOnly = configurations.create("neoForgeConfigOnly", spec -> {
+        userDevConfigOnly = configurations.register("neoForgeConfigOnly", spec -> {
             spec.setDescription("Resolves exclusively the NeoForge userdev JSON for configuring runs");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -97,7 +98,7 @@ public class ModDevRunWorkflow {
             }
         });
 
-        additionalClasspath = configurations.create("additionalRuntimeClasspath", spec -> {
+        additionalClasspath = configurations.register("additionalRuntimeClasspath", spec -> {
             spec.setDescription("Contains dependencies of every run, that should not be considered boot classpath modules.");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -122,7 +123,7 @@ public class ModDevRunWorkflow {
                         modulePath.getDependencies().add(modulePathDependency);
                     }
                 },
-                legacyClassPath -> legacyClassPath.extendsFrom(additionalClasspath),
+                legacyClassPath -> legacyClassPath.extendsFrom(additionalClasspath.get()),
                 artifactsWorkflow.downloadAssets().flatMap(DownloadAssets::getAssetPropertiesFile),
                 versionCapabilities);
     }
@@ -224,7 +225,7 @@ public class ModDevRunWorkflow {
 
         // Create a configuration to resolve DevLaunch and DevLogin without leaking them to consumers
         var supplyDevLogin = project.provider(() -> runs.stream().anyMatch(model -> model.getDevLogin().get()));
-        var devLaunchConfig = project.getConfigurations().create("devLaunchConfig", spec -> {
+        var devLaunchConfig = project.getConfigurations().register("devLaunchConfig", spec -> {
             spec.setDescription("This configuration is used to inject DevLaunch and optionally DevLogin into the runtime classpaths of runs.");
             spec.getDependencies().add(dependencyFactory.create(RunUtils.DEV_LAUNCH_GAV));
             spec.getDependencies().addAllLater(supplyDevLogin.map(
@@ -276,7 +277,7 @@ public class ModDevRunWorkflow {
             Consumer<Configuration> configureModulePath,
             Consumer<Configuration> configureLegacyClasspath, // TODO: can be removed in favor of directly passing a configuration for the moddev libraries
             Provider<RegularFile> assetPropertiesFile,
-            Configuration devLaunchConfig,
+            Provider<Configuration> devLaunchConfig,
             VersionCapabilitiesInternal versionCapabilities,
             TaskProvider<Task> createLaunchScriptsTask) {
         var ideIntegration = IdeIntegration.of(project, branding);
@@ -289,12 +290,13 @@ public class ModDevRunWorkflow {
 
         // Sucks, but what can you do... Only at the end do we actually know which source set this run will use
         project.afterEvaluate(ignored -> {
-            runtimeClasspathConfig.get().extendsFrom(devLaunchConfig);
+            // TODO: this .get() forces a resolution
+            runtimeClasspathConfig.get().extendsFrom(devLaunchConfig.get());
         });
 
         var type = RunUtils.getRequiredType(project, run);
 
-        var modulePathConfiguration = project.getConfigurations().create(InternalModelHelper.nameOfRun(run, "", "modulesOnly"), spec -> {
+        var modulePathConfiguration = configurations.register(InternalModelHelper.nameOfRun(run, "", "modulesOnly"), spec -> {
             spec.setDescription("Libraries that should be placed on the JVMs boot module path for run " + run.getName() + ".");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -302,7 +304,7 @@ public class ModDevRunWorkflow {
             configureModulePath.accept(spec);
         });
 
-        var legacyClasspathConfiguration = configurations.create(InternalModelHelper.nameOfRun(run, "", "legacyClasspath"), spec -> {
+        var legacyClasspathConfiguration = configurations.register(InternalModelHelper.nameOfRun(run, "", "legacyClasspath"), spec -> {
             spec.setDescription("Contains all dependencies of the " + run.getName() + " run that should not be considered boot classpath modules.");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -414,7 +416,7 @@ public class ModDevRunWorkflow {
 
         var testRuntimeClasspath = configurations.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
 
-        var neoForgeModDevModules = project.getConfigurations().create("neoForgeTestModules", spec -> {
+        var neoForgeModDevModules = configurations.register("neoForgeTestModules", spec -> {
             spec.setDescription("Libraries that should be placed on the JVMs boot module path for unit tests.");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -422,7 +424,7 @@ public class ModDevRunWorkflow {
             configureModulePath.accept(spec);
         });
 
-        var legacyClasspathConfiguration = configurations.create("neoForgeTestLibraries", spec -> {
+        var legacyClasspathConfiguration = configurations.register("neoForgeTestLibraries", spec -> {
             spec.setDescription("Contains the legacy classpath of unit tests.");
             spec.setCanBeResolved(true);
             spec.setCanBeConsumed(false);
@@ -482,10 +484,6 @@ public class ModDevRunWorkflow {
         });
 
         ideIntegration.configureTesting(loadedMods, testedMod, runArgsDir, gameDirectory, programArgsFile, vmArgsFile);
-    }
-
-    public Configuration getAdditionalClasspath() {
-        return additionalClasspath;
     }
 
     private static <T extends Named> void setNamedAttribute(Project project, AttributeContainer attributes, Attribute<T> attribute, String value) {

--- a/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimePlugin.java
+++ b/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimePlugin.java
@@ -16,7 +16,7 @@ public class NeoFormRuntimePlugin implements Plugin<Project> {
 
         var nfrtDependency = extension.getVersion().map(version -> dependencyFactory.create("net.neoforged:neoform-runtime:" + version));
 
-        var toolConfiguration = configurations.create("neoFormRuntimeTool", spec -> {
+        var toolConfiguration = configurations.register("neoFormRuntimeTool", spec -> {
             spec.setDescription("The NeoFormRuntime CLI tool");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);
@@ -27,7 +27,7 @@ public class NeoFormRuntimePlugin implements Plugin<Project> {
             });
         });
 
-        var externalToolsConfiguration = configurations.create("neoFormRuntimeExternalTools", spec -> {
+        var externalToolsConfiguration = configurations.register("neoFormRuntimeExternalTools", spec -> {
             spec.setDescription("The external tools used by NeoFormRuntime");
             spec.setCanBeConsumed(false);
             spec.setCanBeResolved(true);


### PR DESCRIPTION
Quickly thrown together, needs cleaning up and testing. The goal here is to move to lazy configuration of `Configuration`s, which will be applicable starting from Gradle 8.14.

I wonder if there would be a way to detect all cases of eager `Configuration` configuration, to make sure that this PR is doing what it advertises.