### PR TITLE
Fix #238: Don't print an error message for the assets on first sync

### DIFF
--- a/src/main/java/net/neoforged/nfrtgradle/DownloadAssets.java
+++ b/src/main/java/net/neoforged/nfrtgradle/DownloadAssets.java
@@ -121,11 +121,16 @@ public abstract class DownloadAssets extends NeoFormRuntimeTask {
 
         var assetReferenceFile = downloadTask.getAssetPropertiesFile();
         if (assetReferenceFile.isPresent()) {
+            var file = assetReferenceFile.getAsFile().get();
+            if (!file.exists()) {
+                logger.info("Asset reference file {} does not exist.", file);
+                return false;
+            }
             DownloadedAssetsReference assetReference;
             try {
-                assetReference = DownloadedAssetsReference.loadProperties(assetReferenceFile.getAsFile().get());
+                assetReference = DownloadedAssetsReference.loadProperties(file);
             } catch (Exception e) {
-                logger.error("Failed to read downloaded asset index: {}", assetReferenceFile);
+                logger.error("Failed to read downloaded asset index: {}", file, e);
                 return false;
             }
             return validateAssetReference(assetReference, logger);


### PR DESCRIPTION
I could reproduce the error mentioned in #238 using an example project from the template generator.