### PR TITLE
fix log highlight in intellij idea

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevRunWorkflow.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevRunWorkflow.java
@@ -244,6 +244,13 @@ public class ModDevRunWorkflow {
                 // This will explicitly be replaced in RunUtils to make this work for IDEs
                 run.getEnvironment().put("MOD_CLASSES", RunUtils.getGradleModFoldersProvider(project, run.getLoadedMods(), null).getClassesArgument());
             }
+
+            //Intellij support colors and control characters,
+            //but TerminalConsoleAppender doesn't implement it correctly,so we force its support to be turned on
+            if (ideIntegration instanceof IntelliJIntegration) {
+                run.getSystemProperties().put("terminal.jline", "true");
+            }
+
             var prepareRunTask = setupRunInGradle(
                     project,
                     branding,


### PR DESCRIPTION
According to [TerminalConsoleAppender](https://github.com/Minecrell/TerminalConsoleAppender/blob/master/src/main/java/net/minecrell/terminalconsole/TerminalConsoleAppender.java#L228-L231),Intellij IDEA supports colors and control characters in terminal, but it go wrong, so i set JLINE_OVERRIDE_PROPERTY to true to enable it.
However, it seems to be a bit difficult for mdg to figure out which ide it running on, so the current implementation require to use run applications after idea's ideSync.
![image](https://github.com/user-attachments/assets/d2baf0c6-9e3c-4253-8086-c50b2fa11b12)
