### PR TITLE
Fix DependencyUtils failing to infer artifact classifier under some circumstances

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/utils/DependencyUtils.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/utils/DependencyUtils.java
@@ -1,7 +1,7 @@
 package net.neoforged.moddevgradle.internal.utils;
 
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -23,15 +23,15 @@ public final class DependencyUtils {
             filename = filename.substring(0, startOfExt);
         }
 
-        if (result.getId() instanceof ModuleComponentArtifactIdentifier moduleId) {
-            var artifact = moduleId.getComponentIdentifier().getModule();
-            var version = moduleId.getComponentIdentifier().getVersion();
+        if (result.getId().getComponentIdentifier() instanceof ModuleComponentIdentifier moduleId) {
+            var artifact = moduleId.getModule();
+            var version = moduleId.getVersion();
             var expectedBasename = artifact + "-" + version;
 
             if (filename.startsWith(expectedBasename + "-")) {
                 classifier = filename.substring((expectedBasename + "-").length());
             }
-            artifactId = moduleId.getComponentIdentifier().getGroup() + ":" + artifact + ":" + version;
+            artifactId = moduleId.getGroup() + ":" + artifact + ":" + version;
         } else {
             // When we encounter a project reference, the component identifier does not expose the group or module name.
             // But we can access the list of capabilities associated with the published variant the artifact originates from.
@@ -40,7 +40,14 @@ public final class DependencyUtils {
             var capabilities = result.getVariant().getCapabilities();
             if (capabilities.size() == 1) {
                 var capability = capabilities.get(0);
-                artifactId = capability.getGroup() + ":" + capability.getName() + ":" + capability.getVersion();
+                var artifact = capability.getName();
+                var version = capability.getVersion();
+                var expectedBasename = artifact + "-" + version;
+
+                if (filename.startsWith(expectedBasename + "-")) {
+                    classifier = filename.substring((expectedBasename + "-").length());
+                }
+                artifactId = capability.getGroup() + ":" + artifact + ":" + version;
             } else {
                 artifactId = result.getId().getComponentIdentifier().toString();
             }


### PR DESCRIPTION
Under some circumstances `DependencyUtils` can fail to infer the artifact classifier for processed dependencies, which causes the `createMinecraftArtifacts` task to fail during source recompilation due to Minecraft's dependencies not resolving correctly.

The specific case in which I encountered this is when using an Artifact Transformer; [here](https://github.com/CursedFlames/javaheaders-mdg-repro/tree/4b5faeb6ee7b7ecbe29c15591ab0519abe811c51) I have a minimal reproduction of this case using the MDK and a dummy artifact transform plugin that applies a no-op to jar dependencies.

I tested that minimal reproduction against this fix and it succeeded to build; in addition the contents of `nfrt_artifact_manifest.properties` were identical to those produced with no artifact transform (after sorting the entries), as expected.

I don't know if this fix will work in every case, but I expect that it should at least work in the vast majority of cases.