### PR TITLE
Bump NFRT to fix validated ATs in Vanilla Mode

### DIFF
--- a/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimeExtension.java
+++ b/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimeExtension.java
@@ -12,7 +12,7 @@ import org.gradle.api.provider.Property;
 public abstract class NeoFormRuntimeExtension {
     public static final String NAME = "neoFormRuntime";
 
-    private static final String DEFAULT_NFRT_VERSION = "1.0.23";
+    private static final String DEFAULT_NFRT_VERSION = "1.0.24";
 
     @Inject
     public NeoFormRuntimeExtension(Project project) {

--- a/testproject/common/build.gradle
+++ b/testproject/common/build.gradle
@@ -10,6 +10,7 @@ neoForge {
     neoFormVersion = "1.21-20240613.152323"
 
     accessTransformers {
+        validateAccessTransformers = true
         from(project.file('accesstransformer.cfg'))
         publish(project.file('accesstransformer.cfg'))
     }


### PR DESCRIPTION
Validated ATs were not being applied when there were no other ATs present (which is the case only in vanilla mode).