### PR TITLE
Allow default reobfuscation task to be disabled in legacy mode

### DIFF
--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/dsl/LegacyForgeModdingSettings.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/dsl/LegacyForgeModdingSettings.java
@@ -20,7 +20,7 @@ public abstract class LegacyForgeModdingSettings {
 
     private Set<SourceSet> enabledSourceSets = new HashSet<>();
 
-    private boolean createDefaultReobfuscationTask = true;
+    private boolean obfuscateJar = true;
 
     @Inject
     public LegacyForgeModdingSettings(Project project) {
@@ -81,11 +81,11 @@ public abstract class LegacyForgeModdingSettings {
     /**
      * {@return true if default reobfuscation task should be created}
      */
-    public boolean shouldCreateDefaultReobfuscationTask() {
-        return createDefaultReobfuscationTask;
+    public boolean isObfuscateJar() {
+        return obfuscateJar;
     }
 
-    public void setCreateDefaultReobfuscationTask(boolean createDefaultReobfuscationTask) {
-        this.createDefaultReobfuscationTask = createDefaultReobfuscationTask;
+    public void setObfuscateJar(boolean obfuscateJar) {
+        this.obfuscateJar = obfuscateJar;
     }
 }

--- a/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
+++ b/src/legacy/java/net/neoforged/moddevgradle/legacyforge/internal/LegacyForgeModDevPlugin.java
@@ -183,7 +183,7 @@ public class LegacyForgeModDevPlugin implements Plugin<Project> {
             run.getProgramArguments().addAll(mixin.getConfigs().map(cfgs -> cfgs.stream().flatMap(config -> Stream.of("--mixin.config", config)).toList()));
         });
 
-        if (settings.shouldCreateDefaultReobfuscationTask()) {
+        if (settings.isObfuscateJar()) {
             var reobfJar = obf.reobfuscate(
                     project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class),
                     project.getExtensions().getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME));

--- a/src/test/java/net/neoforged/moddevgradle/legacyforge/LegacyModDevPluginTest.java
+++ b/src/test/java/net/neoforged/moddevgradle/legacyforge/LegacyModDevPluginTest.java
@@ -118,7 +118,7 @@ public class LegacyModDevPluginTest extends AbstractProjectBuilderTest {
     void testEnableWithoutReobfTask() {
         extension.enable(settings -> {
             settings.setForgeVersion(VERSION);
-            settings.setCreateDefaultReobfuscationTask(false);
+            settings.setObfuscateJar(false);
         });
 
         assertNull(project.getTasks().findByName("reobfJar"));


### PR DESCRIPTION
Useful for projects that need more customization for the remapping logic or that don't need reobfuscation at all.