### PR TITLE
Fix #188: Also add NeoForm dependencies to the artifact manifest, without NeoForge's overrides

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevArtifactsWorkflow.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevArtifactsWorkflow.java
@@ -296,6 +296,21 @@ public record ModDevArtifactsWorkflow(
         });
         result.add(compileClasspath);
 
+        if (moddingPlatformDependency != null) {
+            var compileClasspath2 = configurations.create(configurationPrefix + "CompileClasspath2", spec -> {
+                spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (Classpath) (number 2)");
+                spec.setCanBeConsumed(false);
+                spec.setCanBeResolved(true);
+                spec.getDependencies().add(moddingPlatformDependency.copy()
+                        .capabilities(caps -> caps.requireCapability("net.neoforged:neoforge-dependencies_neoFormOnly")));
+                spec.attributes(attributes -> {
+                    setNamedAttribute(project, attributes, Usage.USAGE_ATTRIBUTE, Usage.JAVA_API);
+                    setNamedAttribute(project, attributes, MinecraftDistribution.ATTRIBUTE, MinecraftDistribution.CLIENT);
+                });
+            });
+            result.add(compileClasspath2);
+        }
+
         // Runtime-time dependencies used by NeoForm, NeoForge and Minecraft.
         var runtimeClasspath = configurations.create(configurationPrefix + "RuntimeClasspath", spec -> {
             spec.setDescription("Dependencies needed for running NeoFormRuntime for the selected NeoForge/NeoForm version (Classpath)");

--- a/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/ModDevPlugin.java
@@ -42,6 +42,8 @@ public class ModDevPlugin implements Plugin<Project> {
                 NeoForgeExtension.class,
                 dataFileCollections.accessTransformers().extension(),
                 dataFileCollections.interfaceInjectionData().extension());
+
+        project.getDependencies().getComponents().withModule("net.neoforged:neoforge", NeoForgeMetadataRule.class);
     }
 
     public void enable(

--- a/src/main/java/net/neoforged/moddevgradle/internal/NeoForgeMetadataRule.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/NeoForgeMetadataRule.java
@@ -1,0 +1,33 @@
+package net.neoforged.moddevgradle.internal;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+public class NeoForgeMetadataRule implements ComponentMetadataRule {
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        // TODO: maybe use maybeAddVariant?
+        context.getDetails().addVariant(
+                "modDevApiElements_neoFormOnly",
+                "modDevApiElements",
+                variantMetadata -> {
+                    variantMetadata.withDependencies(depsMetadata -> {
+                        // Only the NeoForm dependency is endorsing strict versions.
+                        depsMetadata.removeIf(depMetadata -> !depMetadata.isEndorsingStrictVersions());
+                    });
+                    variantMetadata.withCapabilities(capsMetadata -> {
+                        var caps = capsMetadata.getCapabilities();
+                        if (caps.size() != 1) {
+                            throw new RuntimeException("Could not adapt NeoForge metadata: expected exactly one capability for modDevApiElements, found " + caps.size());
+                        }
+                        var cap = caps.get(0);
+                        if (!cap.getGroup().equals("net.neoforged") || !cap.getName().equals("neoforge-dependencies")) {
+                            throw new RuntimeException("Could not adapt NeoForge metadata: expected capability net.neoforged:neoforge-dependencies for modDevApiElements, found " + cap.getGroup() + ":" + cap.getName());
+                        }
+                        capsMetadata.removeCapability("net.neoforged", "neoforge-dependencies");
+                        capsMetadata.addCapability("net.neoforged", "neoforge-dependencies_neoFormOnly", cap.getVersion());
+                    });
+                }
+        );
+    }
+}


### PR DESCRIPTION
This works by using a `ComponentMetadataRule` to add a new variant to the NeoForge dependency that is like the `modDevApiElements` but only with the NeoForm dependency.