### PR TITLE
Add a convention for verbose()

### DIFF
--- a/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimeTask.java
+++ b/src/main/java/net/neoforged/nfrtgradle/NeoFormRuntimeTask.java
@@ -112,6 +112,8 @@ public abstract class NeoFormRuntimeTask extends DefaultTask {
         getInputs().property("artifactManifestEntries", artifactManifestEntries);
         artifacts = project.files();
         getInputs().property("artifacts", artifacts);
+
+        getVerbose().convention(false);
     }
 
     /**


### PR DESCRIPTION
Make NeoFormRuntimeTask a little nicer to use.