### PR TITLE
Avoid write pom file to legacyClasspath when using additionalRuntimeClasspath

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/WriteLegacyClasspath.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/WriteLegacyClasspath.java
@@ -25,9 +25,11 @@ abstract class WriteLegacyClasspath extends DefaultTask {
         getEntries().addAll(getProject().provider(() -> {
             // Use a provider indirection to remove task dependencies.
             // Use file names only.
-            // Remove pom-only artifacts.
             return files.getFiles().stream()
-                    .filter(file -> !file.getName().endsWith("pom"))
+                    // Some dependencies (such as Graal JS) can have non-jar artifacts.
+                    // Leaving them on the legacy CP will crash when SJH fails to open a filesystem for them,
+                    // so we ignore them since they would be ignored on the normal java classpath.
+                    .filter(file -> file.isDirectory() || file.getName().endsWith(".jar") || file.getName().endsWith(".zip"))
                     .map(File::getAbsolutePath)
                     .toList();
         }));


### PR DESCRIPTION
some artifacts like `org.graalvm.js:js` just a pom file which requests other artifact,so mdg only get a pom file and write it to classpath. but we don't have a filesystem for pom,so game crashed.