### PR TITLE
ModDevExtension#getVersion: In vanilla mode, return null instead of throwing

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/dsl/ModDevExtension.java
+++ b/src/main/java/net/neoforged/moddevgradle/dsl/ModDevExtension.java
@@ -1,6 +1,7 @@
 package net.neoforged.moddevgradle.dsl;
 
 import java.io.File;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.neoforged.moddevgradle.internal.Branding;
 import net.neoforged.moddevgradle.internal.IdeIntegration;
@@ -159,12 +160,14 @@ public abstract class ModDevExtension {
 
     /**
      * After enabling modding, you can retrieve the version of the modding platform you picked using this getter.
-     * I.e. the NeoForge or Forge version. If you chose to enable vanilla-only mode, this getter will throw.
+     * I.e. the NeoForge or Forge version. 
+     * <p>
+     * If you chose to enable vanilla-only mode, this getter will return null.
      */
-    public String getVersion() {
+    @Nullable public String getVersion() {
         var dependencies = ModDevArtifactsWorkflow.get(project).dependencies();
         if (dependencies.neoForgeDependency() == null) {
-            throw new InvalidUserCodeException("You cannot retrieve the enabled version if you are in vanilla-only mode.");
+            return null;
         }
         return dependencies.neoForgeDependency().getVersion();
     }


### PR DESCRIPTION
Since there's no way to tell if the extension is using NeoForge or not before calling the `getVersion` method, we're just using an unchecked exception as control flow.  This breaks lots of things downstream, without providing any useful information to the caller except for an unforeseen broken program.

This isn't just a theoretical: a `getVersion` method not throwing is such a common convention that even the MCDev plugin has been rendered inoperable by assuming it wouldn't throw: https://github.com/minecraft-dev/MinecraftDev/issues/2570

As returning null here gives the same amount of information as throwing an exception, and returning null is less likely to break things, this changes it to return null.

(You could also make it a _checked_ exception, so people have a chance to handle it if they miss the docs... but again, that's using exceptions - expensive stacktraces - as control flow, which is very frowned upon for good reason.)

### EDIT:
In truth, this method should really be renamed to `getModloaderVersion`, so it's obvious what its purpose is.  As it stands, `getVersion` would be expected to return the version of the _extension_, not the modloader.