### PR TITLE
Escape each element of the IntelliJ module name

### DIFF
--- a/src/main/java/net/neoforged/moddevgradle/internal/IntelliJIntegration.java
+++ b/src/main/java/net/neoforged/moddevgradle/internal/IntelliJIntegration.java
@@ -256,19 +256,37 @@ final class IntelliJIntegration extends IdeIntegration {
      * Convert a project and source set to an IntelliJ module name.
      * Do not use {@link ModuleRef} as it does not correctly handle projects with a space in their name!
      */
-    private static String getIntellijModuleName(Project project, SourceSet sourceSet) {
+    static String getIntellijModuleName(Project project, SourceSet sourceSet) {
+        // IntelliJ escapes each element of the Gradle path on its own and joins them with '.',
+        // so an element that itself contains a '.' (a subproject named "1.21.1-neoforge", say)
+        // becomes "1_21_1-neoforge". Joining the raw path with '.' instead produces a module
+        // name that does not exist, and the generated run configuration ends up without a module.
+        // See GradleProjectResolverUtil#getHolderModuleName and #escapeModuleNameElement:
+        // https://github.com/JetBrains/intellij-community/blob/711ef1fbda55f43c3943d379f3f16dccfa6760eb/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverUtil.java
         var moduleName = new StringBuilder();
-        // The `replace` call here is our bug fix compared to ModuleRef!
-        // The actual IDEA logic is more complicated, but this should cover the majority of use cases.
-        // See https://github.com/JetBrains/intellij-community/blob/a32fd0c588a6da11fd6d5d2fb0362308da3206f3/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverUtil.java#L205
-        // which calls https://github.com/JetBrains/intellij-community/blob/a32fd0c588a6da11fd6d5d2fb0362308da3206f3/platform/util-rt/src/com/intellij/util/PathUtilRt.java#L120
-        moduleName.append(project.getRootProject().getName().replace(" ", "_"));
+        moduleName.append(escapeModuleNameElement(project.getRootProject().getName()));
         if (project != project.getRootProject()) {
-            moduleName.append(project.getPath().replaceAll(":", "."));
+            for (var element : project.getPath().split(":")) {
+                if (!element.isEmpty()) {
+                    moduleName.append(".").append(escapeModuleNameElement(element));
+                }
+            }
         }
         moduleName.append(".");
-        moduleName.append(sourceSet.getName());
+        moduleName.append(escapeModuleNameElement(sourceSet.getName()));
         return moduleName.toString();
+    }
+
+    /**
+     * Escapes a single element of an IntelliJ module name, mirroring
+     * {@code GradleProjectResolverUtil#escapeModuleNameElement}.
+     */
+    static String escapeModuleNameElement(String element) {
+        return element
+                .replace(" ", "_")
+                .replace("/", "_")
+                .replace("\\", "_")
+                .replace(".", "_");
     }
 
     private static Map<String, Object> getExtraIntelijRunProperties(RunModel run) {

--- a/src/test/java/net/neoforged/moddevgradle/internal/IntelliJIntegrationTest.java
+++ b/src/test/java/net/neoforged/moddevgradle/internal/IntelliJIntegrationTest.java
@@ -1,0 +1,56 @@
+package net.neoforged.moddevgradle.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.neoforged.moddevgradle.internal.utils.ExtensionUtils;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class IntelliJIntegrationTest {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            plain|plain
+            with space|with_space
+            1.21.1-neoforge|1_21_1-neoforge
+            with/slash|with_slash
+            """, delimiter = '|')
+    void testEscapeModuleNameElement(String element, String escaped) {
+        assertEquals(escaped, IntelliJIntegration.escapeModuleNameElement(element));
+    }
+
+    @Test
+    void testModuleNameOfRootProject() {
+        var root = ProjectBuilder.builder().withName("xaeronav").build();
+        assertEquals("xaeronav.main", getMainModuleName(root));
+    }
+
+    /**
+     * IntelliJ escapes each element of the path separately, so a '.' in a subproject name becomes
+     * '_'. Joining the raw path would produce "xaeronav.1.21.1-neoforge.main", which is not a
+     * module that exists, and the run configuration would be written without a module.
+     */
+    @Test
+    void testModuleNameOfSubprojectContainingDots() {
+        var root = ProjectBuilder.builder().withName("xaeronav").build();
+        var subproject = ProjectBuilder.builder().withName("1.21.1-neoforge").withParent(root).build();
+        assertEquals("xaeronav.1_21_1-neoforge.main", getMainModuleName(subproject));
+    }
+
+    @Test
+    void testModuleNameOfNestedSubproject() {
+        var root = ProjectBuilder.builder().withName("root").build();
+        var parent = ProjectBuilder.builder().withName("versions").withParent(root).build();
+        var subproject = ProjectBuilder.builder().withName("1.21.1").withParent(parent).build();
+        assertEquals("root.versions.1_21_1.main", getMainModuleName(subproject));
+    }
+
+    private static String getMainModuleName(Project project) {
+        project.getPluginManager().apply("java");
+        SourceSet sourceSet = ExtensionUtils.getSourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        return IntelliJIntegration.getIntellijModuleName(project, sourceSet);
+    }
+}


### PR DESCRIPTION
Fixes #353

## Problem

`getIntellijModuleName` builds the module name by joining the Gradle path as-is:

```java
moduleName.append(project.getRootProject().getName().replace(" ", "_"));
if (project != project.getRootProject()) {
    moduleName.append(project.getPath().replaceAll(":", "."));
}
moduleName.append(".").append(sourceSet.getName());
```

IntelliJ escapes each element of the path *individually* and then joins the escaped elements with `.`, so an element that itself contains a `.` is not preserved. For a subproject `:1.21.1-neoforge` under root `xaeronav`, IntelliJ's module is `xaeronav.1_21_1-neoforge.main` while the above produces `xaeronav.1.21.1-neoforge.main`.

That name matches no module, so `setModuleName(..)` leaves the generated run configuration without one. IntelliJ then builds `-classpath` from the whole project, which in a multi-loader setup pulls in the other loader's Minecraft and dev launch aborts:

```
Found multiple copies of net/minecraft/server/MinecraftServer.class on the classpath
```

## About the comment above that code

The comment currently points at IntelliJ's `GradleProjectResolverUtil#getInternalModuleName` / `PathUtilRt#suggestFileName` at a pinned revision. That code does not do this escaping — it splits on `:`, joins with `.`, and finishes with `suggestFileName(name, /* allowDots = */ true, false)`, which keeps dots. Read on its own it suggests the current behaviour is correct, which is presumably how this survived.

The escaping happens on the newer sync path, which is what recent IDEA uses:

```java
return Arrays.stream(moduleName.split(":"))
  .map(it -> escapeModuleNameElement(it))
  .collect(Collectors.joining("."));

private static String escapeModuleNameElement(String moduleNameElement) {
  return moduleNameElement
    .replace(" ", "_").replace("/", "_").replace("\\", "_").replace(".", "_");
}
```

and source set modules are `holderModuleName + "." + escapeModuleNameElement(sourceSetName)`.

So I have repointed the comment at those two methods with a pinned permalink, since the stale link is part of why this looked right.

## Fix

Mirror `escapeModuleNameElement` and apply it per element — to the root project name, each path element, and the source set name:

```java
moduleName.append(escapeModuleNameElement(project.getRootProject().getName()));
if (project != project.getRootProject()) {
    for (var element : project.getPath().split(":")) {
        if (!element.isEmpty()) {
            moduleName.append(".").append(escapeModuleNameElement(element));
        }
    }
}
moduleName.append(".").append(escapeModuleNameElement(sourceSet.getName()));
```

This is slightly wider than just handling dots: IntelliJ escapes `/` and `\` too, and applies the same escaping to the root name and the source set name, where the current code only replaced spaces in the root name and did not touch the source set name at all. `getIntellijModuleName` is now package-private so it can be tested.

## Testing

`IntelliJIntegrationTest` — 7 cases: four for `escapeModuleNameElement` (plain, space, dots, slash) and three building names through `ProjectBuilder` (root project, a subproject with dots, and a nested subproject).

Verified with a negative control. Restoring the old assembly (keeping the new helper so the test still compiles) fails exactly the two name tests, with the broken names from the issue:

```
expected: <xaeronav.1_21_1-neoforge.main> but was: <xaeronav.1.21.1-neoforge.main>
expected: <root.versions.1_21_1.main>     but was: <root.versions.1.21.1.main>
```

Restoring the fix returns all 7 to passing.
